### PR TITLE
Enable push notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# SanNext
+
+Este projeto utiliza funções serverless e um front-end estático para gerenciar filas virtuais. Agora há suporte a notificações push para alertar clientes mesmo com o navegador em segundo plano.
+
+## Variáveis de ambiente
+
+Além das chaves já utilizadas para o Redis e outros serviços, são necessários dois valores para o envio das notificações:
+
+- `VAPID_PUBLIC_KEY` – chave pública utilizada na assinatura das mensagens Web Push.
+- `VAPID_PRIVATE_KEY` – chave privada correspondente.
+
+As duas devem ser definidas no ambiente onde as funções serverless são executadas. A chave pública é disponibilizada ao cliente através da função `sendPush` para permitir a assinatura da inscrição.

--- a/functions/chamar.js
+++ b/functions/chamar.js
@@ -1,4 +1,5 @@
 import { Redis } from "@upstash/redis";
+import { handler as sendPush } from "./sendPush.js";
 
 export async function handler(event) {
   const url      = new URL(event.rawUrl);
@@ -76,6 +77,15 @@ export async function handler(event) {
     prefix + "log:called",
     JSON.stringify({ ticket: next, attendant, ts, wait })
   );
+
+  try {
+    await sendPush({
+      httpMethod: 'POST',
+      body: JSON.stringify({ tenantId, message: `Ticket ${next}` })
+    });
+  } catch (err) {
+    console.error('sendPush error', err);
+  }
 
   return {
     statusCode: 200,

--- a/functions/sendPush.js
+++ b/functions/sendPush.js
@@ -1,0 +1,67 @@
+import { Redis } from "@upstash/redis";
+import webpush from "web-push";
+
+const PUBLIC_KEY = process.env.VAPID_PUBLIC_KEY;
+const PRIVATE_KEY = process.env.VAPID_PRIVATE_KEY;
+
+if (PUBLIC_KEY && PRIVATE_KEY) {
+  webpush.setVapidDetails('mailto:example@example.com', PUBLIC_KEY, PRIVATE_KEY);
+}
+
+export async function handler(event) {
+  if (event.httpMethod === 'GET') {
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ publicKey: PUBLIC_KEY || '' }),
+      headers: { 'Content-Type': 'application/json' }
+    };
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: 'Method not allowed' };
+  }
+
+  let body;
+  try {
+    body = JSON.parse(event.body || '{}');
+  } catch {
+    return { statusCode: 400, body: 'Invalid JSON' };
+  }
+
+  const { tenantId, subscription, message } = body;
+  if (!tenantId) return { statusCode: 400, body: 'Missing tenantId' };
+
+  const redis = Redis.fromEnv();
+  const key = `tenant:${tenantId}:pushSubs`;
+
+  if (subscription) {
+    await redis.sadd(key, JSON.stringify(subscription));
+  }
+
+  let subs = [];
+  if (message) {
+    if (subscription) {
+      subs = [subscription];
+    } else {
+      const stored = await redis.smembers(key);
+      subs = stored.map(s => {
+        try { return JSON.parse(s); } catch { return null; }
+      }).filter(Boolean);
+    }
+  }
+
+  let sent = 0;
+  for (const sub of subs) {
+    try {
+      await webpush.sendNotification(sub, JSON.stringify({ title: 'É a sua vez!', body: message }));
+      sent++;
+    } catch (err) {
+      if (err.statusCode === 410 || err.statusCode === 404) {
+        await redis.srem(key, JSON.stringify(sub));
+      }
+      console.error('push error', err);
+    }
+  }
+
+  return { statusCode: 200, body: JSON.stringify({ success: true, sent }) };
+}

--- a/package.json
+++ b/package.json
@@ -12,8 +12,11 @@
     "@upstash/redis": "^1.20.0",
     "uuid": "^9.0.0",
     "bcryptjs": "^2.4.3",
-    "faunadb": "^4.6.0"
+    "faunadb": "^4.6.0",
+    "web-push": "^3.6.7"
   },
+  "devDependencies": {},
+  "optionalDependencies": {},
   "engines": {
     "node": ">=16"
   }

--- a/public/client/js/client.js
+++ b/public/client/js/client.js
@@ -82,6 +82,12 @@ function releaseWakeLock() {
   }
 }
 
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible' && ticketNumber) {
+    requestWakeLock();
+  }
+});
+
 function handleExit(msg) {
   clearInterval(polling);
   clearInterval(alertInterval);
@@ -115,6 +121,7 @@ btnStart.addEventListener("click", () => {
   if (navigator.vibrate) navigator.vibrate(1);
   if ("Notification" in window) Notification.requestPermission();
   overlay.remove();
+  requestWakeLock();
   btnJoin.hidden = true;
   btnCancel.hidden = false;
   btnCancel.disabled = false;
@@ -257,6 +264,7 @@ btnCancel.addEventListener("click", async () => {
 
 btnJoin.addEventListener("click", () => {
   btnJoin.disabled = true;
+  requestWakeLock();
   getTicket();
   subscribePush();
   polling = setInterval(checkStatus, 2000);

--- a/public/client/sw.js
+++ b/public/client/sw.js
@@ -12,3 +12,17 @@ self.addEventListener('notificationclick', e => {
     })
   );
 });
+
+self.addEventListener('push', e => {
+  let data = {};
+  try { data = e.data.json(); } catch {}
+  const title = data.title || 'É a sua vez!';
+  const options = {
+    body: data.body || '',
+    vibrate: [200,100,200],
+    tag: 'sannext-call',
+    renotify: true,
+    requireInteraction: true,
+  };
+  e.waitUntil(self.registration.showNotification(title, options));
+});


### PR DESCRIPTION
## Summary
- add `web-push` dependency and new `sendPush` function to deliver Web Push messages
- request push subscription from the client and register it on the server
- send push alerts when a ticket is called
- make the service worker display notifications from push events
- document environment variables for VAPID keys

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684deced66948329a92677702a698a34