### PR TITLE
Add report generation feature

### DIFF
--- a/functions/atendido.js
+++ b/functions/atendido.js
@@ -41,6 +41,7 @@ export async function handler(event) {
   await redis.set(prefix + "currentCallTs", 0);
   await redis.del(prefix + "currentAttendant");
 
+  // registra a finalização do atendimento
   const ts = Date.now();
   await redis.lpush(
     prefix + "log:attended",

--- a/functions/atendido.js
+++ b/functions/atendido.js
@@ -43,6 +43,7 @@ export async function handler(event) {
 
   // registra a finalização do atendimento
   const ts = Date.now();
+  await redis.set(prefix + `attendedTime:${ticket}`, ts);
   await redis.lpush(
     prefix + "log:attended",
     JSON.stringify({ ticket: Number(ticket), ts, duration, wait })

--- a/functions/cancelar.js
+++ b/functions/cancelar.js
@@ -38,6 +38,7 @@ export async function handler(event) {
     // Log de cancelamento
     // registro do cancelamento com timestamp
     const ts = Date.now();
+    await redis.set(prefix + `cancelledTime:${ticketNum}`, ts);
     await redis.lpush(
       prefix + "log:cancelled",
       JSON.stringify({ ticket: Number(ticketNum), ts, reason, duration: duration ? Number(duration) : 0, wait })

--- a/functions/cancelar.js
+++ b/functions/cancelar.js
@@ -20,8 +20,8 @@ export async function handler(event) {
     const joinTs = await redis.get(prefix + `ticketTime:${ticketNum}`);
     if (joinTs) {
       wait = Date.now() - Number(joinTs);
+      // mantém ticketTime para referência futura
     }
-    await redis.del(prefix + `ticketTime:${ticketNum}`);
   }
 
   const attended = ticketNum

--- a/functions/cancelar.js
+++ b/functions/cancelar.js
@@ -36,6 +36,7 @@ export async function handler(event) {
       await redis.sadd(prefix + "cancelledSet", String(ticketNum));
     }
     // Log de cancelamento
+    // registro do cancelamento com timestamp
     const ts = Date.now();
     await redis.lpush(
       prefix + "log:cancelled",

--- a/functions/chamar.js
+++ b/functions/chamar.js
@@ -49,9 +49,12 @@ export async function handler(event) {
       const dur = prevCallTs ? Date.now() - prevCallTs : 0;
       const waitPrev = Number(await redis.get(prefix + `wait:${prevCall}`) || 0);
       await redis.sadd(prefix + "missedSet", String(prevCall));
+      const missTs = Date.now();
+      // registra o momento em que o ticket perdeu a vez
+      await redis.set(prefix + `cancelledTime:${prevCall}`, missTs);
       await redis.lpush(
         prefix + "log:cancelled",
-        JSON.stringify({ ticket: prevCall, ts: Date.now(), reason: "missed", duration: dur, wait: waitPrev })
+        JSON.stringify({ ticket: prevCall, ts: missTs, reason: "missed", duration: dur, wait: waitPrev })
       );
       await redis.del(prefix + `wait:${prevCall}`);
     }

--- a/functions/chamar.js
+++ b/functions/chamar.js
@@ -65,8 +65,7 @@ export async function handler(event) {
   const joinTs = await redis.get(prefix + `ticketTime:${next}`);
   if (joinTs) {
     wait = ts - Number(joinTs);
-    // remove o registro de entrada ao chamar o cliente
-    await redis.del(prefix + `ticketTime:${next}`);
+    // mantém ticketTime registrado para o relatório
   }
   await redis.set(prefix + `wait:${next}`, wait);
   await redis.set(prefix + "currentCall", next);

--- a/functions/chamar.js
+++ b/functions/chamar.js
@@ -72,6 +72,9 @@ export async function handler(event) {
     await redis.set(prefix + "currentAttendant", attendant);
   }
 
+  // Armazena o timestamp da chamada para consulta posterior
+  await redis.set(prefix + `calledTime:${next}`, ts);
+
   // Log de chamada
   await redis.lpush(
     prefix + "log:called",

--- a/functions/chamar.js
+++ b/functions/chamar.js
@@ -62,6 +62,7 @@ export async function handler(event) {
   const joinTs = await redis.get(prefix + `ticketTime:${next}`);
   if (joinTs) {
     wait = ts - Number(joinTs);
+    // remove o registro de entrada ao chamar o cliente
     await redis.del(prefix + `ticketTime:${next}`);
   }
   await redis.set(prefix + `wait:${next}`, wait);

--- a/functions/entrar.js
+++ b/functions/entrar.js
@@ -15,6 +15,7 @@ export async function handler(event) {
   const clientId     = uuidv4();
   const ticketNumber = await redis.incr(prefix + "ticketCounter");
   await redis.set(prefix + `ticket:${clientId}`, ticketNumber);
+  // registra quando o cliente entrou na fila
   await redis.set(prefix + `ticketTime:${ticketNumber}`, Date.now());
 
   // Log de entrada

--- a/functions/report.js
+++ b/functions/report.js
@@ -88,13 +88,22 @@ export async function handler(event) {
 
   const tickets = Object.values(map).sort((a, b) => a.ticket - b.ticket);
 
-  // Contabiliza totals a partir dos logs caso os sets tenham sido zerados
-  // Fallback para sets caso os logs estejam vazios
-  const attendedCount  = attended.length || attendedNums.length;
-  const cancelledCount =
-    cancelled.filter(c => c.reason !== "missed").length || cancelledNums.length;
-  const missedCount    =
-    cancelled.filter(c => c.reason === "missed").length || missedNums.length;
+  // Contabiliza quantidades de forma robusta combinando logs e sets
+  const attendedTickets  = new Set([
+    ...attendedNums,
+    ...attended.map(a => a.ticket)
+  ]);
+  const cancelledTickets = new Set([
+    ...cancelledNums,
+    ...cancelled.filter(c => c.reason !== "missed").map(c => c.ticket)
+  ]);
+  const missedTickets    = new Set([
+    ...missedNums,
+    ...cancelled.filter(c => c.reason === "missed").map(c => c.ticket)
+  ]);
+  const attendedCount  = attendedTickets.size;
+  const cancelledCount = cancelledTickets.size;
+  const missedCount    = missedTickets.size;
   const waitValues = tickets.map((t) => t.wait).filter((n) => typeof n === "number");
   const durValues  = tickets.map((t) => t.duration).filter((n) => typeof n === "number");
   const totalWait  = waitValues.reduce((sum, v) => sum + v, 0);

--- a/functions/report.js
+++ b/functions/report.js
@@ -1,0 +1,31 @@
+import { Redis } from "@upstash/redis";
+
+export async function handler(event) {
+  const url = new URL(event.rawUrl);
+  const tenantId = url.searchParams.get("t");
+  if (!tenantId) {
+    return { statusCode: 400, body: "Missing tenantId" };
+  }
+
+  const redis = Redis.fromEnv();
+  const prefix = `tenant:${tenantId}:`;
+
+  const logs = await Promise.all([
+    redis.lrange(prefix + "log:entered", 0, -1),
+    redis.lrange(prefix + "log:called", 0, -1),
+    redis.lrange(prefix + "log:attended", 0, -1),
+    redis.lrange(prefix + "log:cancelled", 0, -1),
+  ]);
+
+  const [enteredRaw, calledRaw, attendedRaw, cancelledRaw] = logs;
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      entered: enteredRaw.map(s => JSON.parse(s)),
+      called: calledRaw.map(s => JSON.parse(s)),
+      attended: attendedRaw.map(s => JSON.parse(s)),
+      cancelled: cancelledRaw.map(s => JSON.parse(s)),
+    }),
+  };
+}

--- a/functions/report.js
+++ b/functions/report.js
@@ -38,10 +38,19 @@ export async function handler(event) {
     attendedSet,
   ] = data;
 
-  const entered   = enteredRaw.map((s) => JSON.parse(s));
-  const called    = calledRaw.map((s) => JSON.parse(s));
-  const attended  = attendedRaw.map((s) => JSON.parse(s));
-  const cancelled = cancelledRaw.map((s) => JSON.parse(s));
+  const safeParse = (val) => {
+    if (typeof val !== "string") return null;
+    try {
+      return JSON.parse(val);
+    } catch {
+      return null;
+    }
+  };
+
+  const entered   = enteredRaw.map(safeParse).filter(Boolean);
+  const called    = calledRaw.map(safeParse).filter(Boolean);
+  const attended  = attendedRaw.map(safeParse).filter(Boolean);
+  const cancelled = cancelledRaw.map(safeParse).filter(Boolean);
 
   const cancelledNums = cancelledSet.map((n) => Number(n));
   const missedNums    = missedSet.map((n) => Number(n));

--- a/functions/report.js
+++ b/functions/report.js
@@ -10,6 +10,12 @@ export async function handler(event) {
   const redis = Redis.fromEnv();
   const prefix = `tenant:${tenantId}:`;
 
+  // Verifica se o token/tenant existe
+  const exists = await redis.exists(prefix + "ticketCounter");
+  if (!exists) {
+    return { statusCode: 404, body: "Invalid tenant" };
+  }
+
   const data = await Promise.all([
     redis.lrange(prefix + "log:entered", 0, -1),
     redis.lrange(prefix + "log:called", 0, -1),

--- a/functions/report.js
+++ b/functions/report.js
@@ -102,6 +102,8 @@ export async function handler(event) {
   });
 
   const tickets = Object.values(map).sort((a, b) => a.ticket - b.ticket);
+  // Helper para exibir datas no formato brasileiro
+  const format = (ts) => ts ? new Date(ts).toLocaleString('pt-BR', { timeZone: 'America/Sao_Paulo' }) : null;
 
   // Status e ajustes de tempo atuais
   const now = Date.now();
@@ -123,6 +125,10 @@ export async function handler(event) {
     if (!tk.wait && tk.entered && tk.status === "waiting") {
       tk.wait = now - tk.entered;
     }
+    tk.enteredBr = format(tk.entered);
+    tk.calledBr = format(tk.called);
+    tk.attendedBr = format(tk.attended);
+    tk.cancelledBr = format(tk.cancelled);
   });
 
   // Contabiliza quantidades de forma robusta combinando logs e sets

--- a/functions/report.js
+++ b/functions/report.js
@@ -119,6 +119,7 @@ export async function handler(event) {
   const attendedCount  = attendedTickets.size;
   const cancelledCount = cancelledTickets.size;
   const missedCount    = missedTickets.size;
+  const waitingCount   = Math.max(0, ticketCounter - attendedCount - cancelledCount - missedCount);
   const waitValues = tickets.map((t) => t.wait).filter((n) => typeof n === "number");
   const durValues  = tickets.map((t) => t.duration).filter((n) => typeof n === "number");
   const totalWait  = waitValues.reduce((sum, v) => sum + v, 0);
@@ -135,6 +136,7 @@ export async function handler(event) {
         attendedCount,
         cancelledCount,
         missedCount,
+        waitingCount,
         avgWait,
         avgDur,
       },

--- a/functions/report.js
+++ b/functions/report.js
@@ -89,9 +89,12 @@ export async function handler(event) {
   const tickets = Object.values(map).sort((a, b) => a.ticket - b.ticket);
 
   // Contabiliza totals a partir dos logs caso os sets tenham sido zerados
-  const attendedCount  = attended.length;
-  const cancelledCount = cancelled.filter(c => c.reason !== "missed").length;
-  const missedCount    = cancelled.filter(c => c.reason === "missed").length;
+  // Fallback para sets caso os logs estejam vazios
+  const attendedCount  = attended.length || attendedNums.length;
+  const cancelledCount =
+    cancelled.filter(c => c.reason !== "missed").length || cancelledNums.length;
+  const missedCount    =
+    cancelled.filter(c => c.reason === "missed").length || missedNums.length;
   const waitValues = tickets.map((t) => t.wait).filter((n) => typeof n === "number");
   const durValues  = tickets.map((t) => t.duration).filter((n) => typeof n === "number");
   const totalWait  = waitValues.reduce((sum, v) => sum + v, 0);

--- a/functions/report.js
+++ b/functions/report.js
@@ -124,6 +124,14 @@ export async function handler(event) {
   const tickets = Object.values(map).sort((a, b) => a.ticket - b.ticket);
   // Helper para exibir datas no formato brasileiro
   const format = (ts) => ts ? new Date(ts).toLocaleString('pt-BR', { timeZone: 'America/Sao_Paulo' }) : null;
+  const toHms = (ms) => {
+    if (!ms) return null;
+    const s = Math.floor(ms / 1000);
+    const h = String(Math.floor(s / 3600)).padStart(2, '0');
+    const m = String(Math.floor((s % 3600) / 60)).padStart(2, '0');
+    const sec = String(s % 60).padStart(2, '0');
+    return `${h}:${m}:${sec}`;
+  };
 
   // Status e cálculos de tempo atuais
   const now = Date.now();
@@ -158,6 +166,8 @@ export async function handler(event) {
     tk.calledBr = format(tk.called);
     tk.attendedBr = format(tk.attended);
     tk.cancelledBr = format(tk.cancelled);
+    if (tk.wait) tk.waitHms = toHms(tk.wait);
+    if (tk.duration) tk.durationHms = toHms(tk.duration);
   });
 
   // Contabiliza quantidades de forma robusta combinando logs e sets
@@ -183,6 +193,8 @@ export async function handler(event) {
   const totalDur   = durValues.reduce((sum, v) => sum + v, 0);
   const avgWait    = waitValues.length ? Math.round(totalWait / waitValues.length) : 0;
   const avgDur     = durValues.length ? Math.round(totalDur / durValues.length) : 0;
+  const avgWaitHms = toHms(avgWait);
+  const avgDurHms  = toHms(avgDur);
 
   return {
     statusCode: 200,
@@ -196,6 +208,8 @@ export async function handler(event) {
         waitingCount,
         avgWait,
         avgDur,
+        avgWaitHms,
+        avgDurHms,
       },
     }),
   };

--- a/functions/report.js
+++ b/functions/report.js
@@ -19,13 +19,45 @@ export async function handler(event) {
 
   const [enteredRaw, calledRaw, attendedRaw, cancelledRaw] = logs;
 
+  const entered   = enteredRaw.map(s => JSON.parse(s));
+  const called    = calledRaw.map(s => JSON.parse(s));
+  const attended  = attendedRaw.map(s => JSON.parse(s));
+  const cancelled = cancelledRaw.map(s => JSON.parse(s));
+
+  const map = {};
+  entered.forEach(e => { map[e.ticket] = { ticket: e.ticket, entered: e.ts }; });
+  called.forEach(c => {
+    map[c.ticket] = { ...(map[c.ticket] || { ticket: c.ticket }), called: c.ts, wait: c.wait };
+  });
+  attended.forEach(a => {
+    map[a.ticket] = { ...(map[a.ticket] || { ticket: a.ticket }), attended: a.ts, wait: a.wait, duration: a.duration };
+  });
+  cancelled.forEach(c => {
+    map[c.ticket] = { ...(map[c.ticket] || { ticket: c.ticket }), cancelled: c.ts, reason: c.reason, wait: c.wait, duration: c.duration };
+  });
+
+  const tickets = Object.values(map).sort((a, b) => a.ticket - b.ticket);
+
+  const attendedCount  = tickets.filter(t => t.attended).length;
+  const cancelledCount = tickets.filter(t => t.cancelled && t.reason !== 'missed').length;
+  const missedCount    = tickets.filter(t => t.reason === 'missed').length;
+  const totalWait = tickets.reduce((sum, t) => sum + (t.wait || 0), 0);
+  const totalDur  = tickets.reduce((sum, t) => sum + (t.duration || 0), 0);
+  const avgWait   = attendedCount ? Math.round(totalWait / attendedCount) : 0;
+  const avgDur    = attendedCount ? Math.round(totalDur / attendedCount) : 0;
+
   return {
     statusCode: 200,
     body: JSON.stringify({
-      entered: enteredRaw.map(s => JSON.parse(s)),
-      called: calledRaw.map(s => JSON.parse(s)),
-      attended: attendedRaw.map(s => JSON.parse(s)),
-      cancelled: cancelledRaw.map(s => JSON.parse(s)),
+      tickets,
+      summary: {
+        totalTickets: tickets.length,
+        attendedCount,
+        cancelledCount,
+        missedCount,
+        avgWait,
+        avgDur,
+      },
     }),
   };
 }

--- a/functions/reset.js
+++ b/functions/reset.js
@@ -28,6 +28,12 @@ export async function handler(event) {
   await redis.del(prefix + "log:reset");
   const keys = await redis.keys(prefix + "ticketTime:*");
   for (const k of keys) await redis.del(k);
+  const calledKeys = await redis.keys(prefix + "calledTime:*");
+  for (const k of calledKeys) await redis.del(k);
+  const attendedKeys = await redis.keys(prefix + "attendedTime:*");
+  for (const k of attendedKeys) await redis.del(k);
+  const cancelledKeys = await redis.keys(prefix + "cancelledTime:*");
+  for (const k of cancelledKeys) await redis.del(k);
   const waitKeys = await redis.keys(prefix + "wait:*");
   for (const w of waitKeys) await redis.del(w);
 

--- a/functions/reset.js
+++ b/functions/reset.js
@@ -21,6 +21,15 @@ export async function handler(event) {
   await redis.del(prefix + "cancelledSet");
   await redis.del(prefix + "missedSet");
   await redis.del(prefix + "attendedSet");
+  await redis.del(prefix + "log:entered");
+  await redis.del(prefix + "log:called");
+  await redis.del(prefix + "log:attended");
+  await redis.del(prefix + "log:cancelled");
+  await redis.del(prefix + "log:reset");
+  const keys = await redis.keys(prefix + "ticketTime:*");
+  for (const k of keys) await redis.del(k);
+  const waitKeys = await redis.keys(prefix + "wait:*");
+  for (const w of waitKeys) await redis.del(w);
 
   // Log de reset
   await redis.lpush(

--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -461,6 +461,19 @@ body {
   overflow-y: auto;
   box-shadow: 0 2px 10px rgba(0,0,0,0.3);
 }
+#report-modal h2 {
+  text-align: center;
+  margin-bottom: 0.5rem;
+  color: var(--primary);
+}
+#report-summary {
+  font-size: 0.95rem;
+  margin-bottom: 0.5rem;
+}
+#report-modal .report-actions {
+  margin-top: 1rem;
+  text-align: right;
+}
 #report-modal table {
   width: 100%;
   border-collapse: collapse;

--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -461,6 +461,21 @@ body {
   overflow-y: auto;
   box-shadow: 0 2px 10px rgba(0,0,0,0.3);
 }
+#report-modal table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+  font-size: 0.9rem;
+}
+#report-modal th,
+#report-modal td {
+  border: 1px solid #ccc;
+  padding: 0.25rem 0.5rem;
+  text-align: center;
+}
+#report-modal th {
+  background: #f0f0f0;
+}
 #report-modal .close {
   float: right;
   font-size: 1.25rem;

--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -486,7 +486,7 @@ body {
   padding: 0.4rem 0.6rem;
   text-align: center;
   vertical-align: middle;
-  line-height: 1.4;
+  line-height: 1.8;
 }
 #report-modal th {
   background: #f0f0f0;

--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -483,8 +483,10 @@ body {
 #report-modal th,
 #report-modal td {
   border: 1px solid #ccc;
-  padding: 0.25rem 0.5rem;
+  padding: 0.4rem 0.6rem;
   text-align: center;
+  vertical-align: middle;
+  line-height: 1.4;
 }
 #report-modal th {
   background: #f0f0f0;

--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -438,6 +438,38 @@ body {
   animation: ripple-effect 0.6s linear;
 }
 
+/* Modal de relatório */
+#report-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+#report-modal[hidden] {
+  display: none !important;
+}
+#report-modal .modal-content {
+  background: #fff;
+  padding: 1rem;
+  border-radius: var(--radius);
+  width: 90%;
+  max-width: 600px;
+  max-height: 90%;
+  overflow-y: auto;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.3);
+}
+#report-modal .close {
+  float: right;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+#report-chart {
+  max-width: 100%;
+}
+
 /* Animação de expansão e fade */
 @keyframes ripple-effect {
   to {

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -7,6 +7,10 @@
   <link rel="stylesheet" href="css/monitor-attendant.css"/>
   <!-- Biblioteca de QR Code -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+  <!-- Chart.js para gráficos -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+  <!-- jsPDF para exportação em PDF -->
+  <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
 </head>
 <body>
   <!-- Overlay de Onboarding -->
@@ -86,6 +90,7 @@
       </div>
 
       <button id="btn-reset" class="btn btn-warning">Resetar Tickets</button>
+      <button id="btn-report" class="btn btn-secondary">Relatório</button>
     </section>
 
     <!-- Histórico de Cancelados -->
@@ -111,5 +116,19 @@
   </main>
 
   <script src="js/monitor-attendant.js"></script>
+
+  <!-- Modal de Relatório -->
+  <div id="report-modal" hidden>
+    <div class="modal-content">
+      <span id="report-close" class="close">&times;</span>
+      <h2>Relatório</h2>
+      <div id="report-summary"></div>
+      <canvas id="report-chart" width="400" height="200"></canvas>
+      <div class="report-actions">
+        <button id="export-csv" class="btn btn-secondary">Exportar CSV</button>
+        <button id="export-pdf" class="btn btn-secondary">Exportar PDF</button>
+      </div>
+    </div>
+  </div>
 </body>
 </html>

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -123,6 +123,7 @@
       <span id="report-close" class="close">&times;</span>
       <h2>Relatório</h2>
       <div id="report-summary"></div>
+      <table id="report-table"></table>
       <canvas id="report-chart" width="400" height="200"></canvas>
       <div class="report-actions">
         <button id="export-csv" class="btn btn-secondary">Exportar CSV</button>

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -121,7 +121,7 @@
   <div id="report-modal" hidden>
     <div class="modal-content">
       <span id="report-close" class="close">&times;</span>
-      <h2>Relatório</h2>
+      <h2 id="report-title">Relatório</h2>
       <div id="report-summary"></div>
       <table id="report-table"></table>
       <canvas id="report-chart" width="400" height="200"></canvas>

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -126,7 +126,7 @@
       <table id="report-table"></table>
       <canvas id="report-chart" width="400" height="200"></canvas>
       <div class="report-actions">
-        <button id="export-csv" class="btn btn-secondary">Exportar CSV</button>
+        <button id="export-excel" class="btn btn-secondary">Exportar Excel</button>
         <button id="export-pdf" class="btn btn-secondary">Exportar PDF</button>
       </div>
     </div>

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -361,13 +361,21 @@ function startBouncingCompanyName(text) {
 
     // Monta tabela
     const table = document.getElementById('report-table');
-    table.innerHTML = '<thead><tr><th>Ticket</th><th>Entrada</th><th>Chamada</th><th>Atendido</th><th>Cancelado</th><th>Motivo</th><th>Espera(s)</th><th>Duração(s)</th></tr></thead>';
+    table.innerHTML = '<thead><tr><th>Ticket</th><th>Status</th><th>Entrada</th><th>Chamada</th><th>Atendido</th><th>Cancelado</th><th>Motivo</th><th>Espera(s)</th><th>Duração(s)</th></tr></thead>';
     const tbody = document.createElement('tbody');
     const fmt = ts => ts ? new Date(ts).toLocaleString('pt-BR') : '-';
+    const label = (st) => ({
+      attended: 'Atendido',
+      cancelled: 'Cancelado',
+      missed: 'Perdeu a vez',
+      called: 'Chamado',
+      waiting: 'Em espera'
+    })[st] || '';
     tickets.forEach(tk => {
       const tr = document.createElement('tr');
       tr.innerHTML = `
         <td>${tk.ticket}</td>
+        <td>${label(tk.status)}</td>
         <td>${fmt(tk.entered)}</td>
         <td>${fmt(tk.called)}</td>
         <td>${fmt(tk.attended)}</td>
@@ -388,10 +396,11 @@ function startBouncingCompanyName(text) {
     window.reportChart = new Chart(ctx, { type:'bar', data:{ labels, datasets:[{ label:'Chamadas/hora', data, backgroundColor:'#0077cc'}] } });
 
     document.getElementById('export-csv').onclick = () => {
-      const rows = [['ticket','entered','called','attended','cancelled','reason','wait_ms','duration_ms']];
+      const rows = [['ticket','status','entered','called','attended','cancelled','reason','wait_ms','duration_ms']];
       if (tickets.length) {
         tickets.forEach(tk => rows.push([
           tk.ticket,
+          tk.status,
           tk.entered || '',
           tk.called || '',
           tk.attended || '',
@@ -401,8 +410,8 @@ function startBouncingCompanyName(text) {
           tk.duration || ''
         ]));
       } else {
-        rows.push(['', '', '', attendedCount, cancelledCount, 'missed:'+missedCount, '', '']);
-        rows.push(['', '', '', '', '', 'waiting:'+waitingCount, '', '']);
+        rows.push(['', '', '', attendedCount, cancelledCount, 'missed:'+missedCount, '', '', '']);
+        rows.push(['', '', '', '', '', 'waiting:'+waitingCount, '', '', '']);
       }
       const csv = rows.map(r => r.join(',')).join('\n');
       const blob = new Blob([csv], { type:'text/csv' });

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -469,11 +469,12 @@ function startBouncingCompanyName(text) {
         `Tempo médio de espera: ${avgWaitHms}`,
         `Tempo médio de atendimento: ${avgDurHms}`
       ];
-      summaryLines.forEach(line => { doc.text(line, 14, y); y += 6; });
+      summaryLines.forEach(line => { doc.text(line, 20, y); y += 7; });
 
       const headers = ['Ticket','Status','Entrada','Chamada','Atendido','Cancelado','Espera','Duração'];
-      const colW = [12, 22, 25, 25, 25, 25, 20, 20];
-      const startX = 14;
+      const colW = [10, 20, 25, 25, 25, 25, 20, 20];
+      const startX = 20;
+      const rowH = 7;
       const drawRow = (vals, yPos, bold = false) => {
         let x = startX;
         if (bold) doc.setFont(undefined, 'bold'); else doc.setFont(undefined, 'normal');
@@ -483,12 +484,12 @@ function startBouncingCompanyName(text) {
         });
       };
 
-      drawRow(headers, y, true); y += 6;
+      drawRow(headers, y, true); y += rowH;
       tickets.forEach(tk => {
         if (y > 270) {
           doc.addPage();
           y = 20;
-          drawRow(headers, y, true); y += 6;
+          drawRow(headers, y, true); y += rowH;
         }
         drawRow([
           tk.ticket,
@@ -500,12 +501,12 @@ function startBouncingCompanyName(text) {
           tk.waitHms || msToHms(tk.wait) || '',
           tk.durationHms || msToHms(tk.duration) || ''
         ], y);
-        y += 6;
+        y += rowH;
       });
 
       doc.addPage();
       const img = reportChartEl.toDataURL('image/png');
-      doc.addImage(img, 'PNG', 15, 20, 180, 80);
+      doc.addImage(img, 'PNG', 20, 20, 170, 80);
 
       doc.save('relatorio.pdf');
     };

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -118,7 +118,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let missedCount    = 0;
   let attendedNums   = [];
   let attendedCount  = 0;
-  const fmtTime     = ts => new Date(ts).toLocaleTimeString();
+  const fmtTime     = ts => new Date(ts).toLocaleString('pt-BR');
 
  /** Renderiza o QR Code e configura interação */
 function renderQRCode(tId) {
@@ -334,7 +334,7 @@ function startBouncingCompanyName(text) {
     const table = document.getElementById('report-table');
     table.innerHTML = '<thead><tr><th>Ticket</th><th>Entrada</th><th>Chamada</th><th>Atendido</th><th>Cancelado</th><th>Motivo</th><th>Espera(s)</th><th>Duração(s)</th></tr></thead>';
     const tbody = document.createElement('tbody');
-    const fmt = ts => ts ? new Date(ts).toLocaleTimeString('pt-BR', {hour:'2-digit', minute:'2-digit'}) : '-';
+    const fmt = ts => ts ? new Date(ts).toLocaleString('pt-BR') : '-';
     tickets.forEach(tk => {
       const tr = document.createElement('tr');
       tr.innerHTML = `

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -450,7 +450,7 @@ function startBouncingCompanyName(text) {
 
     document.getElementById('export-pdf').onclick = () => {
       const { jsPDF } = window.jspdf;
-      const doc = new jsPDF('p', 'mm', 'a4');
+      const doc = new jsPDF('l', 'mm', 'a4');
       const nowStr = new Date().toLocaleString('pt-BR');
 
       doc.setFontSize(16);
@@ -472,22 +472,22 @@ function startBouncingCompanyName(text) {
       summaryLines.forEach(line => { doc.text(line, 20, y); y += 7; });
 
       const headers = ['Ticket','Status','Entrada','Chamada','Atendido','Cancelado','Espera','Duração'];
-      const colW = [10, 20, 25, 25, 25, 25, 20, 20];
+      const colW = [15, 30, 35, 35, 35, 35, 25, 25];
       const startX = 20;
-      const rowH = 7;
+      const rowH = 9;
       const drawRow = (vals, yPos, bold = false) => {
         let x = startX;
         if (bold) doc.setFont(undefined, 'bold'); else doc.setFont(undefined, 'normal');
         vals.forEach((v, i) => {
-          doc.text(String(v ?? ''), x, yPos, { maxWidth: colW[i] - 1 });
+          doc.text(String(v ?? ''), x + colW[i] / 2, yPos, { maxWidth: colW[i] - 1, align: 'center' });
           x += colW[i];
         });
       };
 
       drawRow(headers, y, true); y += rowH;
       tickets.forEach(tk => {
-        if (y > 270) {
-          doc.addPage();
+        if (y > 190) {
+          doc.addPage('l');
           y = 20;
           drawRow(headers, y, true); y += rowH;
         }
@@ -504,7 +504,7 @@ function startBouncingCompanyName(text) {
         y += rowH;
       });
 
-      doc.addPage();
+      doc.addPage('l');
       const img = reportChartEl.toDataURL('image/png');
       doc.addImage(img, 'PNG', 20, 20, 170, 80);
 

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -310,8 +310,26 @@ function startBouncingCompanyName(text) {
 
   async function openReport(t) {
     reportModal.hidden = false;
-    const res = await fetch(`/.netlify/functions/report?t=${t}`);
-    const { tickets = [], summary = {} } = await res.json();
+    reportSummary.innerHTML = '';
+    if (!t) {
+      reportSummary.innerHTML = '<p>Token inválido ou ausente.</p>';
+      return;
+    }
+    let tickets = [];
+    let summary = {};
+    try {
+      const res = await fetch(`/.netlify/functions/report?t=${t}`);
+      if (!res.ok) {
+        const text = await res.text();
+        reportSummary.innerHTML = `<p>Erro ao gerar relatório: ${text}</p>`;
+        return;
+      }
+      ({ tickets = [], summary = {} } = await res.json());
+    } catch (err) {
+      console.error('fetch report error', err);
+      reportSummary.innerHTML = '<p>Erro de conexão ao gerar relatório.</p>';
+      return;
+    }
 
     const {
       totalTickets = 0,

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -322,13 +322,17 @@ function startBouncingCompanyName(text) {
       avgDur = 0
     } = summary;
 
-    reportSummary.innerHTML = `
-      <p>Total de tickets: ${totalTickets}</p>
-      <p>Atendidos: ${attendedCount}</p>
-      <p>Tempo médio de espera: ${Math.round(avgWait/1000)}s</p>
-      <p>Tempo médio de atendimento: ${Math.round(avgDur/1000)}s</p>
-      <p>Cancelados: ${cancelledCount}</p>
-      <p>Perderam a vez: ${missedCount}</p>`;
+    if (!tickets.length) {
+      reportSummary.innerHTML = '<p>Nenhum dado encontrado.</p>';
+    } else {
+      reportSummary.innerHTML = `
+        <p>Total de tickets: ${totalTickets}</p>
+        <p>Atendidos: ${attendedCount}</p>
+        <p>Tempo médio de espera: ${Math.round(avgWait/1000)}s</p>
+        <p>Tempo médio de atendimento: ${Math.round(avgDur/1000)}s</p>
+        <p>Cancelados: ${cancelledCount}</p>
+        <p>Perderam a vez: ${missedCount}</p>`;
+    }
 
     // Monta tabela
     const table = document.getElementById('report-table');
@@ -351,7 +355,7 @@ function startBouncingCompanyName(text) {
     table.appendChild(tbody);
 
     const byHour = {};
-    tickets.forEach(c => { if(c.called){ const h = new Date(c.called).getHours(); byHour[h]=(byHour[h]||0)+1; }});
+    tickets.forEach(c => { if (c.called) { const h = new Date(c.called).getHours(); byHour[h] = (byHour[h] || 0) + 1; }});
     const labels = Object.keys(byHour).sort((a,b)=>a-b);
     const data = labels.map(h => byHour[h]);
     const ctx = reportChartEl.getContext('2d');
@@ -359,6 +363,7 @@ function startBouncingCompanyName(text) {
     window.reportChart = new Chart(ctx, { type:'bar', data:{ labels, datasets:[{ label:'Chamadas/hora', data, backgroundColor:'#0077cc'}] } });
 
     document.getElementById('export-csv').onclick = () => {
+      if (!tickets.length) return;
       const rows = [['ticket','entered','called','attended','cancelled','reason','wait_ms','duration_ms']];
       tickets.forEach(tk => rows.push([
         tk.ticket,
@@ -377,6 +382,7 @@ function startBouncingCompanyName(text) {
     };
 
     document.getElementById('export-pdf').onclick = () => {
+      if (!tickets.length) return;
       const { jsPDF } = window.jspdf;
       const doc = new jsPDF();
       doc.text('Relatório', 10, 10);

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -361,7 +361,7 @@ function startBouncingCompanyName(text) {
 
     // Monta tabela
     const table = document.getElementById('report-table');
-    table.innerHTML = '<thead><tr><th>Ticket</th><th>Status</th><th>Entrada</th><th>Chamada</th><th>Atendido</th><th>Cancelado</th><th>Motivo</th><th>Espera(s)</th><th>Duração(s)</th></tr></thead>';
+    table.innerHTML = '<thead><tr><th>Ticket</th><th>Status</th><th>Entrada</th><th>Chamada</th><th>Atendido</th><th>Cancelado</th><th>Espera(s)</th><th>Duração(s)</th></tr></thead>';
     const tbody = document.createElement('tbody');
     const fmt = ts => ts ? new Date(ts).toLocaleString('pt-BR') : '-';
     const label = (st) => ({
@@ -380,7 +380,6 @@ function startBouncingCompanyName(text) {
         <td>${tk.calledBr || fmt(tk.called)}</td>
         <td>${tk.attendedBr || fmt(tk.attended)}</td>
         <td>${tk.cancelledBr || fmt(tk.cancelled)}</td>
-        <td>${tk.reason || ''}</td>
         <td>${tk.wait ? Math.round(tk.wait/1000) : '-'}</td>
         <td>${tk.duration ? Math.round(tk.duration/1000) : '-'}</td>`;
       tbody.appendChild(tr);
@@ -396,7 +395,7 @@ function startBouncingCompanyName(text) {
     window.reportChart = new Chart(ctx, { type:'bar', data:{ labels, datasets:[{ label:'Chamadas/hora', data, backgroundColor:'#0077cc'}] } });
 
     document.getElementById('export-csv').onclick = () => {
-      const rows = [['ticket','status','entered','called','attended','cancelled','reason','wait_ms','duration_ms']];
+      const rows = [['ticket','status','entered','called','attended','cancelled','wait_ms','duration_ms']];
       if (tickets.length) {
         tickets.forEach(tk => rows.push([
           tk.ticket,
@@ -405,13 +404,12 @@ function startBouncingCompanyName(text) {
           tk.calledBr || fmt(tk.called) || '',
           tk.attendedBr || fmt(tk.attended) || '',
           tk.cancelledBr || fmt(tk.cancelled) || '',
-          tk.reason || '',
           tk.wait || '',
           tk.duration || ''
         ]));
       } else {
-        rows.push(['', '', '', attendedCount, cancelledCount, 'missed:'+missedCount, '', '', '']);
-        rows.push(['', '', '', '', '', 'waiting:'+waitingCount, '', '', '']);
+        rows.push(['', '', '', attendedCount, cancelledCount, 'missed:'+missedCount, '', '']);
+        rows.push(['', '', '', '', '', 'waiting:'+waitingCount, '', '']);
       }
       const csv = rows.map(r => r.join(',')).join('\n');
       const blob = new Blob([csv], { type:'text/csv' });

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -412,7 +412,7 @@ function startBouncingCompanyName(text) {
 
     document.getElementById('export-excel').onclick = () => {
       const encoder = new TextEncoder();
-      const esc = (s) => s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+      const esc = (s) => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
       const col = (i) => String.fromCharCode(65 + i);
 
       const headers = ['Ticket','Status','Entrada','Chamada','Atendido','Cancelado','Espera','Duração'];

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -322,7 +322,11 @@ function startBouncingCompanyName(text) {
       avgDur = 0
     } = summary;
 
-    if (!tickets.length) {
+    if (!tickets.length &&
+        !totalTickets &&
+        !attendedCount &&
+        !cancelledCount &&
+        !missedCount) {
       reportSummary.innerHTML = '<p>Nenhum dado encontrado.</p>';
     } else {
       reportSummary.innerHTML = `
@@ -363,18 +367,21 @@ function startBouncingCompanyName(text) {
     window.reportChart = new Chart(ctx, { type:'bar', data:{ labels, datasets:[{ label:'Chamadas/hora', data, backgroundColor:'#0077cc'}] } });
 
     document.getElementById('export-csv').onclick = () => {
-      if (!tickets.length) return;
       const rows = [['ticket','entered','called','attended','cancelled','reason','wait_ms','duration_ms']];
-      tickets.forEach(tk => rows.push([
-        tk.ticket,
-        tk.entered || '',
-        tk.called || '',
-        tk.attended || '',
-        tk.cancelled || '',
-        tk.reason || '',
-        tk.wait || '',
-        tk.duration || ''
-      ]));
+      if (tickets.length) {
+        tickets.forEach(tk => rows.push([
+          tk.ticket,
+          tk.entered || '',
+          tk.called || '',
+          tk.attended || '',
+          tk.cancelled || '',
+          tk.reason || '',
+          tk.wait || '',
+          tk.duration || ''
+        ]));
+      } else {
+        rows.push(['', '', '', attendedCount, cancelledCount, 'missed:'+missedCount, '', '']);
+      }
       const csv = rows.map(r => r.join(',')).join('\n');
       const blob = new Blob([csv], { type:'text/csv' });
       const link = document.createElement('a');
@@ -382,7 +389,6 @@ function startBouncingCompanyName(text) {
     };
 
     document.getElementById('export-pdf').onclick = () => {
-      if (!tickets.length) return;
       const { jsPDF } = window.jspdf;
       const doc = new jsPDF();
       doc.text('Relatório', 10, 10);
@@ -392,6 +398,7 @@ function startBouncingCompanyName(text) {
       doc.text(`Tempo médio de atendimento: ${Math.round(avgDur/1000)}s`, 10, 50);
       doc.text(`Cancelados: ${cancelledCount}`, 10, 60);
       doc.text(`Perderam a vez: ${missedCount}`, 10, 70);
+      if (tickets.length) doc.text('Detalhes em anexo', 10, 80);
       doc.save('relatorio.pdf');
     };
 

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -336,6 +336,7 @@ function startBouncingCompanyName(text) {
       attendedCount = 0,
       cancelledCount = 0,
       missedCount = 0,
+      waitingCount = 0,
       avgWait = 0,
       avgDur = 0
     } = summary;
@@ -344,7 +345,8 @@ function startBouncingCompanyName(text) {
         !totalTickets &&
         !attendedCount &&
         !cancelledCount &&
-        !missedCount) {
+        !missedCount &&
+        !waitingCount) {
       reportSummary.innerHTML = '<p>Nenhum dado encontrado.</p>';
     } else {
       reportSummary.innerHTML = `
@@ -353,7 +355,8 @@ function startBouncingCompanyName(text) {
         <p>Tempo médio de espera: ${Math.round(avgWait/1000)}s</p>
         <p>Tempo médio de atendimento: ${Math.round(avgDur/1000)}s</p>
         <p>Cancelados: ${cancelledCount}</p>
-        <p>Perderam a vez: ${missedCount}</p>`;
+        <p>Perderam a vez: ${missedCount}</p>
+        <p>Em espera: ${waitingCount}</p>`;
     }
 
     // Monta tabela
@@ -399,6 +402,7 @@ function startBouncingCompanyName(text) {
         ]));
       } else {
         rows.push(['', '', '', attendedCount, cancelledCount, 'missed:'+missedCount, '', '']);
+        rows.push(['', '', '', '', '', 'waiting:'+waitingCount, '', '']);
       }
       const csv = rows.map(r => r.join(',')).join('\n');
       const blob = new Blob([csv], { type:'text/csv' });
@@ -416,7 +420,8 @@ function startBouncingCompanyName(text) {
       doc.text(`Tempo médio de atendimento: ${Math.round(avgDur/1000)}s`, 10, 50);
       doc.text(`Cancelados: ${cancelledCount}`, 10, 60);
       doc.text(`Perderam a vez: ${missedCount}`, 10, 70);
-      if (tickets.length) doc.text('Detalhes em anexo', 10, 80);
+      doc.text(`Em espera: ${waitingCount}`, 10, 80);
+      if (tickets.length) doc.text('Detalhes em anexo', 10, 90);
       doc.save('relatorio.pdf');
     };
 

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -376,10 +376,10 @@ function startBouncingCompanyName(text) {
       tr.innerHTML = `
         <td>${tk.ticket}</td>
         <td>${label(tk.status)}</td>
-        <td>${fmt(tk.entered)}</td>
-        <td>${fmt(tk.called)}</td>
-        <td>${fmt(tk.attended)}</td>
-        <td>${fmt(tk.cancelled)}</td>
+        <td>${tk.enteredBr || fmt(tk.entered)}</td>
+        <td>${tk.calledBr || fmt(tk.called)}</td>
+        <td>${tk.attendedBr || fmt(tk.attended)}</td>
+        <td>${tk.cancelledBr || fmt(tk.cancelled)}</td>
         <td>${tk.reason || ''}</td>
         <td>${tk.wait ? Math.round(tk.wait/1000) : '-'}</td>
         <td>${tk.duration ? Math.round(tk.duration/1000) : '-'}</td>`;
@@ -401,10 +401,10 @@ function startBouncingCompanyName(text) {
         tickets.forEach(tk => rows.push([
           tk.ticket,
           tk.status,
-          tk.entered || '',
-          tk.called || '',
-          tk.attended || '',
-          tk.cancelled || '',
+          tk.enteredBr || fmt(tk.entered) || '',
+          tk.calledBr || fmt(tk.called) || '',
+          tk.attendedBr || fmt(tk.attended) || '',
+          tk.cancelledBr || fmt(tk.cancelled) || '',
           tk.reason || '',
           tk.wait || '',
           tk.duration || ''

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -410,17 +410,14 @@ function startBouncingCompanyName(text) {
     if (window.reportChart) window.reportChart.destroy();
     window.reportChart = new Chart(ctx, { type:'bar', data:{ labels, datasets:[{ label:'Chamadas/hora', data, backgroundColor:'#0077cc'}] } });
 
-    document.getElementById('export-csv').onclick = () => {
+    document.getElementById('export-excel').onclick = () => {
       const nowStr = new Date().toLocaleString('pt-BR');
-      const header = ['Ticket','Status','Entrada','Chamada','Atendido','Cancelado','Espera','Duração'];
-      const rows = [
-        ['Empresa', cfg?.empresa || ''],
-        ['Gerado em', nowStr],
-        [],
-        header
-      ];
-      if (tickets.length) {
-        tickets.forEach(tk => rows.push([
+      const headers = ['Ticket','Status','Entrada','Chamada','Atendido','Cancelado','Espera','Duração'];
+      let html = `<table><tr><th colspan="2">${cfg?.empresa || ''}</th></tr>` +
+                 `<tr><td>Gerado em</td><td>${nowStr}</td></tr></table>`;
+      html += '<table><tr>' + headers.map(h => `<th>${h}</th>`).join('') + '</tr>';
+      tickets.forEach(tk => {
+        html += '<tr>' + [
           tk.ticket,
           label(tk.status),
           tk.enteredBr || fmt(tk.entered) || '',
@@ -429,22 +426,25 @@ function startBouncingCompanyName(text) {
           tk.cancelledBr || fmt(tk.cancelled) || '',
           tk.waitHms || msToHms(tk.wait) || '',
           tk.durationHms || msToHms(tk.duration) || ''
-        ]));
-      }
-      rows.push([]);
-      rows.push(['Total tickets', totalTickets]);
-      rows.push(['Atendidos', attendedCount]);
-      rows.push(['Cancelados', cancelledCount]);
-      rows.push(['Perderam a vez', missedCount]);
-      rows.push(['Em espera', waitingCount]);
-      rows.push(['Tempo médio de espera', avgWaitHms]);
-      rows.push(['Tempo médio de atendimento', avgDurHms]);
+        ].map(v => `<td>${v}</td>`).join('') + '</tr>';
+      });
+      html += '</table>';
+      html += '<table>' +
+        `<tr><td>Total tickets</td><td>${totalTickets}</td></tr>` +
+        `<tr><td>Atendidos</td><td>${attendedCount}</td></tr>` +
+        `<tr><td>Cancelados</td><td>${cancelledCount}</td></tr>` +
+        `<tr><td>Perderam a vez</td><td>${missedCount}</td></tr>` +
+        `<tr><td>Em espera</td><td>${waitingCount}</td></tr>` +
+        `<tr><td>Tempo médio de espera</td><td>${avgWaitHms}</td></tr>` +
+        `<tr><td>Tempo médio de atendimento</td><td>${avgDurHms}</td></tr>` +
+        '</table>';
 
-      const csv = rows.map(r => r.join(',')).join('\n');
-      const blob = new Blob([csv], { type:'text/csv' });
+      const blob = new Blob([`\uFEFF<html><head><meta charset="UTF-8"></head><body>${html}</body></html>`], {
+        type: 'application/vnd.ms-excel'
+      });
       const link = document.createElement('a');
       link.href = URL.createObjectURL(blob);
-      link.download = 'relatorio.csv';
+      link.download = 'relatorio.xls';
       link.click();
     };
 


### PR DESCRIPTION
## Summary
- create serverless `report` function that aggregates log data
- add report button and modal to attendant interface
- load Chart.js and jsPDF from CDN
- implement client-side report generation with export to CSV/PDF
- style modal for better UX

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ec98cdf0c832983549cecae902f4e