### PR TITLE
Add manual ticket name support

### DIFF
--- a/functions/status.js
+++ b/functions/status.js
@@ -15,6 +15,7 @@ export async function handler(event) {
   const ticketCounter = Number(await redis.get(prefix + "ticketCounter") || 0);
   const attendant     = (await redis.get(prefix + "currentAttendant")) || "";
   const timestamp     = Number(await redis.get(prefix + "currentCallTs")  || 0);
+  const currentName   = await redis.get(prefix + `name:${currentCall}`);
   const [cancelledSet, missedSet, attendedSet] = await Promise.all([
     redis.smembers(prefix + "cancelledSet"),
     redis.smembers(prefix + "missedSet"),
@@ -28,10 +29,17 @@ export async function handler(event) {
   const attendedCount = attendedNums.length;
   const waiting       = Math.max(0, ticketCounter - cancelledCount - missedCount - attendedCount);
 
+  const nameKeys = [];
+  for (let i = 1; i <= ticketCounter; i++) nameKeys.push(prefix + `name:${i}`);
+  const nameVals = await redis.mget(...nameKeys);
+  const names = {};
+  nameVals.forEach((v, idx) => { if (v) names[idx + 1] = v; });
+
   return {
     statusCode: 200,
     body: JSON.stringify({
       currentCall,
+      currentName,
       callCounter,
       ticketCounter,
       attendant,
@@ -43,6 +51,7 @@ export async function handler(event) {
       attendedNumbers: attendedNums,
       attendedCount,
       waiting,
+      names,
     }),
   };
 }

--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -11,6 +11,15 @@
   --muted:      #666;
   --radius:     6px;
   --font:       'Helvetica Neue', Arial, sans-serif;
+  --manual:     #f5a623;
+}
+
+@keyframes blink {
+  0%, 50%, 100% { opacity: 1; }
+  25%, 75%     { opacity: 0; }
+}
+.blink {
+  animation: blink 1s linear infinite;
 }
 
 * {
@@ -197,6 +206,13 @@ body {
   font-weight: bold;
   color: var(--secondary);
 }
+#current-name {
+  margin-left: 0.5rem;
+  font-weight: bold;
+}
+.manual-name {
+  color: var(--manual);
+}
 .id-label {
   margin-left: 0.5rem;
   font-size: 1rem;
@@ -239,6 +255,18 @@ body {
   margin: 0.5rem 0;
 }
 .manual select {
+  flex: 1;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: var(--radius);
+}
+
+.manual-entry {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+.manual-entry input {
   flex: 1;
   padding: 0.5rem;
   border: 1px solid #ccc;

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -74,6 +74,7 @@
     <section class="call-panel">
       <div class="display">
         Chamando: <span id="current-call">–</span>
+        <span id="current-name" class="current-name"></span>
         <small id="current-id" class="id-label"></small>
       </div>
       <button id="btn-next" class="btn btn-primary">Próximo</button>
@@ -83,6 +84,10 @@
       <div class="manual">
         <select id="manual-select"></select>
         <button id="btn-manual" class="btn btn-secondary">Chamar</button>
+      </div>
+      <div class="manual-entry">
+        <input id="manual-name" type="text" placeholder="Nome do cliente" />
+        <button id="btn-add-ticket" class="btn btn-secondary">Gerar Manual</button>
       </div>
 
       <div class="status-info">

--- a/public/monitor/css/monitor.css
+++ b/public/monitor/css/monitor.css
@@ -22,3 +22,18 @@ h1 {
   font-weight: bold;
   color: #0077cc;
 }
+.name {
+  font-size: 3rem;
+  font-weight: bold;
+  margin-top: 0.5rem;
+}
+.manual-name {
+  color: #f5a623;
+}
+@keyframes blink { 0%,50%,100%{opacity:1;} 25%,75%{opacity:0;} }
+.blink { animation: blink 1s linear infinite; }
+#btn-silence {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+}

--- a/public/monitor/index.html
+++ b/public/monitor/index.html
@@ -10,6 +10,9 @@
   <div class="container">
     <h1>Chamando</h1>
     <div id="current" class="number">—</div>
+    <div id="current-name" class="name"></div>
+    <button id="btn-silence" hidden>Silenciar alerta</button>
+    <audio id="alert-sound" preload="auto" src="https://actions.google.com/sounds/v1/alarms/alarm_clock.ogg"></audio>
   </div>
   <script src="js/monitor.js"></script>
 </body>

--- a/public/monitor/js/monitor.js
+++ b/public/monitor/js/monitor.js
@@ -1,15 +1,52 @@
 
 // public/monitor/js/monitor.js
+const currentEl = document.getElementById('current');
+const nameEl    = document.getElementById('current-name');
+const btnSilence= document.getElementById('btn-silence');
+const alertSound= document.getElementById('alert-sound');
+
+let lastCall = 0;
+let lastName = '';
+let silenced = false;
+
+btnSilence.addEventListener('click', () => {
+  silenced = true;
+  alertSound.pause();
+  alertSound.currentTime = 0;
+  speechSynthesis.cancel();
+  btnSilence.hidden = true;
+  nameEl.classList.remove('blink');
+});
+
 async function fetchCurrent() {
   try {
     const res = await fetch('/.netlify/functions/status');
-    const { currentCall } = await res.json();
-    document.getElementById('current').textContent = currentCall;
+    const { currentCall, currentName = '', names = {} } = await res.json();
+    currentEl.textContent = currentCall;
+    const name = currentName || names[currentCall] || '';
+    nameEl.textContent = name;
+    if (name) {
+      nameEl.classList.toggle('manual-name', true);
+    } else {
+      nameEl.classList.remove('manual-name');
+    }
+    if (currentCall !== lastCall || name !== lastName) {
+      lastCall = currentCall;
+      lastName = name;
+      if (currentCall) {
+        silenced = false;
+        btnSilence.hidden = false;
+        nameEl.classList.add('blink');
+        alertSound.currentTime = 0;
+        alertSound.play().catch(()=>{});
+        const utter = new SpeechSynthesisUtterance(`É a sua vez: ${currentCall} ${name}`);
+        speechSynthesis.speak(utter);
+      }
+    }
   } catch (e) {
     console.error('Erro ao buscar currentCall:', e);
   }
 }
 
-// Polling a cada 2 segundos
 fetchCurrent();
 setInterval(fetchCurrent, 2000);


### PR DESCRIPTION
## Summary
- allow naming tickets on creation via `entrar`
- expose ticket names through status and reports
- show manual ticket names and creation UI in attendant panel
- highlight and speak ticket names on the monitor

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685423baa6448329b478df466ce673bb