### PR TITLE
Fix monitor beep by passing tenant ID

### DIFF
--- a/functions/chamar.js
+++ b/functions/chamar.js
@@ -37,10 +37,11 @@ export async function handler(event) {
     }
   }
 
-  // Quando um número é chamado manualmente (paramNum),
-  // não devemos marcar o chamado anterior como perdido,
-  // pois ele continua aguardando na fila
-  if (!paramNum && prevCall && prevCall !== next) {
+  // Quando a chamada é automática (Next), o ticket anteriormente
+  // chamado só perde a vez se avançarmos para um número maior
+  // que ele. Isso evita que chamados manuais removam números
+  // menores da fila.
+  if (!paramNum && prevCall && next > prevCall) {
     const [isCancelled, isMissed, isAttended] = await Promise.all([
       redis.sismember(prefix + "cancelledSet", String(prevCall)),
       redis.sismember(prefix + "missedSet", String(prevCall)),

--- a/functions/chamar.js
+++ b/functions/chamar.js
@@ -20,10 +20,8 @@ export async function handler(event) {
   const counterKey = prefix + "callCounter";
   if (paramNum) {
     next = Number(paramNum);
-    const currentCounter = Number(await redis.get(counterKey) || 0);
-    if (next > currentCounter) {
-      await redis.set(counterKey, next);
-    }
+    // Não atualiza o contador sequencial para manter a ordem quando
+    // um número é chamado manualmente
     await redis.srem(prefix + "cancelledSet", String(next));
     await redis.srem(prefix + "missedSet", String(next));
   } else {

--- a/functions/chamar.js
+++ b/functions/chamar.js
@@ -37,7 +37,10 @@ export async function handler(event) {
     }
   }
 
-  if (prevCall && prevCall !== next) {
+  // Quando um número é chamado manualmente (paramNum),
+  // não devemos marcar o chamado anterior como perdido,
+  // pois ele continua aguardando na fila
+  if (!paramNum && prevCall && prevCall !== next) {
     const [isCancelled, isMissed, isAttended] = await Promise.all([
       redis.sismember(prefix + "cancelledSet", String(prevCall)),
       redis.sismember(prefix + "missedSet", String(prevCall)),

--- a/public/client/js/client.js
+++ b/public/client/js/client.js
@@ -243,6 +243,9 @@ btnSilence.addEventListener("click", () => {
 });
 
 btnCancel.addEventListener("click", async () => {
+  const confirmExit = confirm("Tem certeza que deseja sair da fila?");
+  if (!confirmExit) return;
+
   btnCancel.disabled = true;
   statusEl.textContent = "Cancelando...";
   clearInterval(alertInterval);

--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -183,11 +183,16 @@ body {
   border-radius: var(--radius);
 }
 
-.call-panel, .history-panel {
+.call-panel, .history-panel, .queue-panel {
   background: #fff;
   padding: 1rem;
   border-radius: var(--radius);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+.queue-panel h2 {
+  font-size: 1.25rem;
+  color: var(--primary);
+  margin-bottom: 0.5rem;
 }
 .display {
   font-size: 1.5rem;

--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -244,7 +244,7 @@ body {
   padding: 0.5rem;
   border: 1px solid #ccc;
   border-radius: var(--radius);
-  max-width: 10rem;
+  max-width: 14rem; /* show numbers with short names */
 }
 .manual button {
   white-space: nowrap;

--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -233,22 +233,6 @@ body {
   background: #f2a100;
 }
 
-.manual {
-  display: flex;
-  gap: 0.5rem;
-  margin: 0.5rem 0;
-}
-.manual select {
-  flex: 1;
-  min-width: 0;
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  border-radius: var(--radius);
-  max-width: 14rem; /* show numbers with short names */
-}
-.manual button {
-  white-space: nowrap;
-}
 
 .status-info {
   font-size: 1rem;

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -80,11 +80,7 @@
       <button id="btn-repeat" class="btn btn-secondary">Repetir</button>
       <button id="btn-attended" class="btn btn-success">Atendido</button>
 
-      <div class="manual">
-        <select id="manual-select"></select>
-        <button id="btn-manual" class="btn btn-secondary">Chamar</button>
-        <button id="btn-new-manual" class="btn btn-secondary">Ticket</button>
-      </div>
+      <button id="btn-new-manual" class="btn btn-secondary">Ticket</button>
 
       <div class="status-info">
         Em espera: <span id="waiting-count">–</span> clientes

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -90,6 +90,12 @@
       <button id="btn-report" class="btn btn-secondary">Relatório</button>
     </section>
 
+    <!-- Fila Virtual -->
+    <section class="queue-panel">
+      <h2>Fila Virtual</h2>
+      <ul id="queue-list" class="list"></ul>
+    </section>
+
     <!-- Histórico de Cancelados -->
     <section class="history-panel">
       <h2>Cancelados (<span id="cancel-count">0</span>)</h2>

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -78,6 +78,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const attendedListEl = document.getElementById('attended-list');
   const attendedThumbsEl = document.getElementById('attended-thumbs');
   const attendedCountEl  = document.getElementById('attended-count');
+  const queueListEl    = document.getElementById('queue-list');
   const btnNext        = document.getElementById('btn-next');
   const btnRepeat      = document.getElementById('btn-repeat');
   const btnAttended    = document.getElementById('btn-attended');
@@ -115,6 +116,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let currentCallNum = 0; // último número chamado exibido
   let ticketNames    = {};
   let ticketCounter  = 0;
+  let callCounter    = 0;
   let cancelledNums  = [];
   let missedNums     = [];
   let cancelledCount = 0;
@@ -192,6 +194,23 @@ function startBouncingCompanyName(text) {
     currentIdEl.textContent   = attendantId || '';
   }
 
+  function updateQueueList() {
+    if (!queueListEl) return;
+    queueListEl.innerHTML = '';
+    const pending = [];
+    for (let i = callCounter + 1; i <= ticketCounter; i++) {
+      if (i === currentCallNum) continue;
+      if (cancelledNums.includes(i) || missedNums.includes(i) || attendedNums.includes(i)) continue;
+      pending.push(i);
+    }
+    pending.forEach(n => {
+      const li = document.createElement('li');
+      const nm = ticketNames[n];
+      li.textContent = nm ? `${n} - ${nm}` : String(n);
+      queueListEl.appendChild(li);
+    });
+  }
+
   /** Busca status e atualiza UI */
   async function fetchStatus(t) {
     try {
@@ -199,6 +218,7 @@ function startBouncingCompanyName(text) {
       const {
         currentCall,
         ticketCounter: tc,
+        callCounter: cCtr = 0,
         cancelledNumbers = [],
         missedNumbers = [],
         attendedNumbers = [],
@@ -211,6 +231,7 @@ function startBouncingCompanyName(text) {
 
       currentCallNum  = currentCall;
       ticketCounter   = tc;
+      callCounter     = cCtr;
       ticketNames     = names || {};
       cancelledNums   = cancelledNumbers.map(Number);
       missedNums      = missedNumbers.map(Number);
@@ -250,6 +271,8 @@ function startBouncingCompanyName(text) {
         div.textContent = n;
         attendedThumbsEl.appendChild(div);
       });
+
+      updateQueueList();
 
       // Exibe o botão de relatório apenas se houver tickets registrados
       btnReport.hidden = ticketCounter === 0;

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -115,8 +115,9 @@ document.addEventListener('DOMContentLoaded', () => {
   qrOverlay.appendChild(qrOverlayContent);
   document.body.appendChild(qrOverlay);
 
-  let currentCallNum = 0; // último número chamado
-  let ticketNames  = {};
+  let currentCallNum = 0; // último número chamado exibido
+  let callCounter    = 0; // último número chamado automaticamente
+  let ticketNames    = {};
   let ticketCounter  = 0;
   let cancelledNums  = [];
   let missedNums     = [];
@@ -201,6 +202,7 @@ function startBouncingCompanyName(text) {
       const res = await fetch(`/.netlify/functions/status?t=${t}`);
       const {
         currentCall,
+        callCounter: cCounter = 0,
         ticketCounter: tc,
         cancelledNumbers = [],
         missedNumbers = [],
@@ -213,6 +215,7 @@ function startBouncingCompanyName(text) {
       } = await res.json();
 
       currentCallNum  = currentCall;
+      callCounter     = cCounter;
       ticketCounter   = tc;
       ticketNames     = names || {};
       cancelledNums   = cancelledNumbers.map(Number);
@@ -267,7 +270,9 @@ function startBouncingCompanyName(text) {
   function updateManualOptions() {
     selectManual.innerHTML = '<option value="">Selecione...</option>';
     const MAX_LEN = 15;
-    for (let i = currentCallNum + 1; i <= ticketCounter; i++) {
+    // Baseia-se no contador sequencial para manter números antigos
+    // disponíveis mesmo após uma chamada manual
+    for (let i = callCounter + 1; i <= ticketCounter; i++) {
       if (cancelledNums.includes(i) || missedNums.includes(i) || attendedNums.includes(i)) continue;
       const opt = document.createElement('option');
       opt.value = i;

--- a/public/monitor/css/monitor.css
+++ b/public/monitor/css/monitor.css
@@ -39,3 +39,19 @@ h1 {
   0%,50%,100% { opacity:1; }
   25%,75% { opacity:0; }
 }
+
+/* Overlay para solicitar que o usuário habilite o áudio */
+#unlock-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,0.7);
+  color: #fff;
+  font-size: 2rem;
+  z-index: 1000;
+}
+#unlock-overlay.hidden {
+  display: none;
+}

--- a/public/monitor/index.html
+++ b/public/monitor/index.html
@@ -12,6 +12,7 @@
     <div id="current" class="number">—</div>
   <div id="current-name" class="name"></div>
   </div>
+  <div id="unlock-overlay" class="hidden">Clique ou toque para ativar o som</div>
   <audio id="alert-sound" preload="auto" src="https://actions.google.com/sounds/v1/alarms/alarm_clock.ogg"></audio>
   <script src="js/monitor.js"></script>
 </body>

--- a/public/monitor/js/monitor.js
+++ b/public/monitor/js/monitor.js
@@ -7,6 +7,23 @@ const tenantId  = urlParams.get('t');
 let lastCall = 0;
 const alertSound = document.getElementById('alert-sound');
 
+// Desbloqueia o audio na primeira interação do usuário para evitar
+// que o navegador bloqueie a execução do som de alerta
+if (alertSound) {
+  const unlock = () => {
+    alertSound.volume = 0;
+    alertSound.play().then(() => {
+      alertSound.pause();
+      alertSound.currentTime = 0;
+      alertSound.volume = 1;
+    }).catch(() => {});
+    document.removeEventListener('click', unlock);
+    document.removeEventListener('touchstart', unlock);
+  };
+  document.addEventListener('click', unlock, { once: true });
+  document.addEventListener('touchstart', unlock, { once: true });
+}
+
 function alertUser(num, name) {
   if (alertSound) {
     alertSound.currentTime = 0;

--- a/public/monitor/js/monitor.js
+++ b/public/monitor/js/monitor.js
@@ -1,5 +1,9 @@
 
 // public/monitor/js/monitor.js
+// Captura o tenantId a partir da URL para poder consultar o status correto
+const urlParams = new URL(location).searchParams;
+const tenantId  = urlParams.get('t');
+
 let lastCall = 0;
 const alertSound = document.getElementById('alert-sound');
 
@@ -17,7 +21,8 @@ function alertUser(num, name) {
 
 async function fetchCurrent() {
   try {
-    const res = await fetch('/.netlify/functions/status');
+    const url = '/.netlify/functions/status' + (tenantId ? `?t=${tenantId}` : '');
+    const res = await fetch(url);
     const { currentCall, names = {} } = await res.json();
     const currentEl = document.getElementById('current');
     const nameEl = document.getElementById('current-name');

--- a/public/monitor/js/monitor.js
+++ b/public/monitor/js/monitor.js
@@ -1,11 +1,12 @@
 
 // public/monitor/js/monitor.js
 // Captura o tenantId a partir da URL para poder consultar o status correto
-const urlParams = new URL(location).searchParams;
+const urlParams = new URL(window.location.href).searchParams;
 const tenantId  = urlParams.get('t');
 
 let lastCall = 0;
-const alertSound = document.getElementById('alert-sound');
+const alertSound   = document.getElementById('alert-sound');
+const unlockOverlay = document.getElementById('unlock-overlay');
 
 // Desbloqueia o audio na primeira interação do usuário para evitar
 // que o navegador bloqueie a execução do som de alerta
@@ -16,12 +17,15 @@ if (alertSound) {
       alertSound.pause();
       alertSound.currentTime = 0;
       alertSound.volume = 1;
+      if (unlockOverlay) unlockOverlay.classList.add('hidden');
     }).catch(() => {});
     document.removeEventListener('click', unlock);
     document.removeEventListener('touchstart', unlock);
+    if (unlockOverlay) unlockOverlay.removeEventListener('click', unlock);
   };
   document.addEventListener('click', unlock, { once: true });
   document.addEventListener('touchstart', unlock, { once: true });
+  if (unlockOverlay) unlockOverlay.addEventListener('click', unlock);
 }
 
 function alertUser(num, name) {


### PR DESCRIPTION
## Summary
- parse `t` parameter in monitor page
- send tenant id when polling for status

## Testing
- `npm install --ignore-scripts`
- `npm run build`
- `node functions/status.js` *(fails: missing Redis env vars)*

------
https://chatgpt.com/codex/tasks/task_e_6854abf5cb148329b6a7b94ba53d25fb