### PR TITLE
Implement multi-device monitor login

### DIFF
--- a/functions/deleteMonitorConfig.js
+++ b/functions/deleteMonitorConfig.js
@@ -34,9 +34,17 @@ exports.handler = async (event) => {
   }
 
   try {
+    const data = await redis.get(`monitor:${token}`);
+    let empresa;
+    if (data) {
+      try { empresa = JSON.parse(data).empresa; } catch {}
+    }
     // Remove também índice possivelmente cadastrado (tenantByEmail), se existir
     await redis.del(`monitor:${token}`);
     await redis.del(`tenantByEmail:${token}`);
+    if (empresa) {
+      await redis.del(`monitorByEmpresa:${empresa.toLowerCase()}`);
+    }
     return {
       statusCode: 200,
       body: JSON.stringify({ ok: true })

--- a/functions/extendSubscription.js
+++ b/functions/extendSubscription.js
@@ -37,7 +37,15 @@ exports.handler = async (event) => {
 
   const novoTTL = ttlNow + extraDays * 24 * 60 * 60;
   try {
+    const data = await redisExt.get(`monitor:${token}`);
+    let empresa;
+    if (data) {
+      try { empresa = JSON.parse(data).empresa; } catch {}
+    }
     await redisExt.expire(`monitor:${token}`, novoTTL);
+    if (empresa) {
+      await redisExt.expire(`monitorByEmpresa:${empresa.toLowerCase()}`, novoTTL);
+    }
     return {
       statusCode: 200,
       body: JSON.stringify({ ok: true, expiresIn: novoTTL })

--- a/functions/getMonitorToken.js
+++ b/functions/getMonitorToken.js
@@ -1,0 +1,44 @@
+const { Redis } = require('@upstash/redis');
+
+const redis = new Redis({
+  url: process.env.UPSTASH_REDIS_REST_URL,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN,
+});
+
+exports.handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: JSON.stringify({ error: 'Método não permitido' }) };
+  }
+
+  let body;
+  try {
+    body = JSON.parse(event.body);
+  } catch {
+    return { statusCode: 400, body: JSON.stringify({ error: 'JSON inválido' }) };
+  }
+
+  const { empresa, senha } = body;
+  if (!empresa || !senha) {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Dados incompletos' }) };
+  }
+
+  const key = `monitorByEmpresa:${empresa.toLowerCase()}`;
+  try {
+    const token = await redis.get(key);
+    if (!token) {
+      return { statusCode: 404, body: JSON.stringify({ error: 'Empresa não encontrada' }) };
+    }
+    const data = await redis.get(`monitor:${token}`);
+    if (!data) {
+      return { statusCode: 404, body: JSON.stringify({ error: 'Configuração não encontrada' }) };
+    }
+    const stored = JSON.parse(data);
+    if (stored.senha !== senha) {
+      return { statusCode: 403, body: JSON.stringify({ error: 'Senha inválida' }) };
+    }
+    return { statusCode: 200, body: JSON.stringify({ token }) };
+  } catch (err) {
+    console.error('getMonitorToken error:', err);
+    return { statusCode: 500, body: JSON.stringify({ error: err.message }) };
+  }
+};

--- a/functions/saveMonitorConfig.js
+++ b/functions/saveMonitorConfig.js
@@ -31,6 +31,11 @@ exports.handler = async (event) => {
       JSON.stringify({ empresa, senha }),
       { ex: ttl }
     );
+    await redis.set(
+      `monitorByEmpresa:${empresa.toLowerCase()}`,
+      token,
+      { ex: ttl }
+    );
     return {
       statusCode: 200,
       body: JSON.stringify({ ok: true, expiresIn: ttl })

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -31,6 +31,7 @@
       <label>Senha de Acesso</label>
       <input id="onboard-password" type="password" placeholder="Defina uma senha" autocomplete="new-password" />
       <button id="onboard-submit">Criar Monitor</button>
+      <button id="onboard-existing" type="button">Já tenho monitor</button>
       <div id="onboard-error" class="error"></div>
     </div>
   </div>
@@ -39,6 +40,7 @@
   <div id="login-overlay" hidden>
     <div class="login-box">
       <h2>Login Atendente</h2>
+      <input id="login-company" type="text" placeholder="Empresa" />
       <input id="login-password" type="password" placeholder="Senha" autocomplete="current-password" />
       <button id="login-submit">Entrar</button>
       <div id="login-error" class="error"></div>

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -34,6 +34,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const onboardPassword = document.getElementById('onboard-password');
   const onboardSubmit   = document.getElementById('onboard-submit');
   const onboardError    = document.getElementById('onboard-error');
+  const onboardExisting = document.getElementById('onboard-existing');
+
+  const loginCompany  = document.getElementById('login-company');
+  const loginPassword = document.getElementById('login-password');
+  const loginSubmit   = document.getElementById('login-submit');
+  const loginError    = document.getElementById('login-error');
 
   // Botão Redefinir Cadastro
   const btnDeleteConfig = document.getElementById('btn-delete-config');
@@ -666,6 +672,38 @@ function startBouncingCompanyName(text) {
     // 3) Senão, exibir onboarding para trial
     onboardOverlay.hidden = false;
     loginOverlay.hidden   = true;
+
+    onboardExisting.onclick = () => {
+      onboardOverlay.hidden = true;
+      loginOverlay.hidden = false;
+    };
+
+    loginSubmit.onclick = async () => {
+      const empresa = loginCompany.value.trim();
+      const pw      = loginPassword.value;
+      if (!empresa || !pw) {
+        loginError.textContent = 'Preencha empresa e senha.';
+        return;
+      }
+      loginError.textContent = '';
+      try {
+        const res = await fetch(`${location.origin}/.netlify/functions/getMonitorToken`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ empresa, senha: pw })
+        });
+        const data = await res.json();
+        if (!res.ok || !data.token) throw new Error();
+        token = data.token;
+        cfg = { token, empresa, senha: pw };
+        localStorage.setItem('monitorConfig', JSON.stringify(cfg));
+        history.replaceState(null, '', `/monitor-attendant/?empresa=${encodeURIComponent(empresa)}`);
+        showApp(empresa, token);
+      } catch (e) {
+        console.error(e);
+        loginError.textContent = 'Empresa ou senha inválida.';
+      }
+    };
 
     onboardSubmit.onclick = async () => {
       const label = onboardLabel.value.trim();


### PR DESCRIPTION
## Summary
- map company names to tokens when saving configuration
- cleanup mapping on deletion and extend its TTL alongside monitor
- add function `getMonitorToken` to retrieve token by company and password
- update attendant monitor UI to allow login for existing companies

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685f2966dac08329911660955e311f00