### PR TITLE
Improve monitor token error handling

### DIFF
--- a/functions/getMonitorToken.js
+++ b/functions/getMonitorToken.js
@@ -1,7 +1,5 @@
 import { Redis } from '@upstash/redis';
 
-const redis = Redis.fromEnv();
-
 export async function handler(event) {
   if (event.httpMethod !== 'POST') {
     return {
@@ -23,6 +21,18 @@ export async function handler(event) {
   }
 
   const key = `monitorByEmpresa:${empresa.toLowerCase()}`;
+
+  let redis;
+  try {
+    redis = Redis.fromEnv();
+  } catch (err) {
+    console.error('Redis init error:', err);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Server configuration error' })
+    };
+  }
+
   try {
     const token = await redis.get(key);
     if (!token) {

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -692,9 +692,17 @@ function startBouncingCompanyName(text) {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ empresa, senha: pw })
         });
-        const data = await res.json();
+        let data;
+        try {
+          data = await res.json();
+        } catch (parseErr) {
+          console.error('JSON parse error:', parseErr);
+          loginError.textContent = 'Erro inesperado no servidor.';
+          return;
+        }
         if (!res.ok || !data.token) {
-          throw new Error(data.error || `HTTP ${res.status}`);
+          const msg = typeof data.error === 'string' ? data.error : `HTTP ${res.status}`;
+          throw new Error(msg);
         }
         token = data.token;
         cfg = { token, empresa, senha: pw };


### PR DESCRIPTION
## Summary
- handle missing Redis credentials and initialize inside handler
- guard against invalid JSON on login in monitor-attendant.js

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f322a85e4832993a331406702f3b5