### PR TITLE
Improve monitor token error handling

### DIFF
--- a/functions/getMonitorToken.js
+++ b/functions/getMonitorToken.js
@@ -1,47 +1,91 @@
 import { Redis } from '@upstash/redis';
 
-const redis = Redis.fromEnv();
-
 export async function handler(event) {
   if (event.httpMethod !== 'POST') {
     return {
       statusCode: 405,
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ error: 'Método não permitido' })
     };
   }
 
   let body;
   try {
-    body = JSON.parse(event.body || '{}');
+    if (typeof event.body === 'string') {
+      body = JSON.parse(event.body || '{}');
+    } else {
+      body = event.body || {};
+    }
   } catch {
-    return { statusCode: 400, body: JSON.stringify({ error: 'JSON inválido' }) };
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'JSON inválido' })
+    };
   }
 
   const { empresa, senha } = body;
   if (!empresa || !senha) {
-    return { statusCode: 400, body: JSON.stringify({ error: 'Dados incompletos' }) };
+    return {
+      statusCode: 400,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Dados incompletos' })
+    };
   }
 
   const key = `monitorByEmpresa:${empresa.toLowerCase()}`;
+
+  let redis;
+  try {
+    redis = Redis.fromEnv();
+  } catch (err) {
+    console.error('Redis init error:', err);
+    return {
+      statusCode: 500,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Server configuration error' })
+    };
+  }
+
   try {
     const token = await redis.get(key);
     if (!token) {
-      return { statusCode: 404, body: JSON.stringify({ error: 'Empresa não encontrada' }) };
+      return {
+        statusCode: 404,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ error: 'Empresa não encontrada' })
+      };
     }
 
     const data = await redis.get(`monitor:${token}`);
     if (!data) {
-      return { statusCode: 404, body: JSON.stringify({ error: 'Configuração não encontrada' }) };
+      return {
+        statusCode: 404,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ error: 'Configuração não encontrada' })
+      };
     }
 
     const stored = JSON.parse(data);
     if (stored.senha !== senha) {
-      return { statusCode: 403, body: JSON.stringify({ error: 'Senha inválida' }) };
+      return {
+        statusCode: 403,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ error: 'Senha inválida' })
+      };
     }
 
-    return { statusCode: 200, body: JSON.stringify({ token }) };
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token })
+    };
   } catch (err) {
     console.error('getMonitorToken error:', err);
-    return { statusCode: 500, body: JSON.stringify({ error: err.message }) };
+    return {
+      statusCode: 500,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: err.message })
+    };
   }
 }

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -692,9 +692,22 @@ function startBouncingCompanyName(text) {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ empresa, senha: pw })
         });
-        const data = await res.json();
+        let data;
+        const text = await res.text();
+        try {
+          if (res.headers.get('content-type')?.includes('application/json')) {
+            data = JSON.parse(text);
+          } else {
+            throw new Error('Response is not JSON');
+          }
+        } catch (parseErr) {
+          console.error('JSON parse error:', parseErr, text);
+          loginError.textContent = `Erro ${res.status}: resposta inválida.`;
+          return;
+        }
         if (!res.ok || !data.token) {
-          throw new Error(data.error || `HTTP ${res.status}`);
+          const msg = typeof data.error === 'string' ? data.error : `HTTP ${res.status}`;
+          throw new Error(msg);
         }
         token = data.token;
         cfg = { token, empresa, senha: pw };


### PR DESCRIPTION
## Summary
- add consistent JSON headers in `getMonitorToken`
- handle cases where the fetch response isn't JSON and show HTTP status

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f322a85e4832993a331406702f3b5