### PR TITLE
Add monitor share QR

### DIFF
--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -494,6 +494,37 @@ body {
   max-width: 100%;
 }
 
+/* Modal para duplicar monitor */
+#share-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+#share-modal[hidden] {
+  display: none !important;
+}
+#share-modal .modal-content {
+  background: #fff;
+  padding: 1rem;
+  border-radius: var(--radius);
+  width: 90%;
+  max-width: 400px;
+  text-align: center;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.3);
+}
+#share-modal .close {
+  float: right;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+#share-qrcode {
+  margin: 1rem auto;
+}
+
 /* Animação de expansão e fade */
 @keyframes ripple-effect {
   to {

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -31,7 +31,6 @@
       <label>Senha de Acesso</label>
       <input id="onboard-password" type="password" placeholder="Defina uma senha" autocomplete="new-password" />
       <button id="onboard-submit">Criar Monitor</button>
-      <button id="onboard-existing" type="button">Já tenho monitor</button>
       <div id="onboard-error" class="error"></div>
     </div>
   </div>
@@ -63,6 +62,9 @@
   </div>
   <button id="btn-delete-config" class="btn btn-secondary">
     Redefinir Cadastro
+  </button>
+  <button id="btn-share-monitor" class="btn btn-secondary">
+    Duplicar Monitor
   </button>
 </header>
 
@@ -143,6 +145,16 @@
         <button id="export-excel" class="btn btn-secondary">Exportar Excel</button>
         <button id="export-pdf" class="btn btn-secondary">Exportar PDF</button>
       </div>
+    </div>
+  </div>
+
+  <!-- Modal de Duplicação do Monitor -->
+  <div id="share-modal" hidden>
+    <div class="modal-content">
+      <span id="share-close" class="close">&times;</span>
+      <h2>Duplicar Monitor</h2>
+      <div id="share-qrcode"></div>
+      <p>Escaneie para abrir este monitor em outro dispositivo.</p>
     </div>
   </div>
 </body>

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const urlParams     = new URL(location).searchParams;
   let token           = urlParams.get('t');
   let empresaParam    = urlParams.get('empresa');
+  let senhaParam      = urlParams.get('senha');
   const storedConfig  = localStorage.getItem('monitorConfig');
   let cfg             = storedConfig ? JSON.parse(storedConfig) : null;
 
@@ -34,7 +35,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const onboardPassword = document.getElementById('onboard-password');
   const onboardSubmit   = document.getElementById('onboard-submit');
   const onboardError    = document.getElementById('onboard-error');
-  const onboardExisting = document.getElementById('onboard-existing');
 
   const loginCompany  = document.getElementById('login-company');
   const loginPassword = document.getElementById('login-password');
@@ -91,11 +91,15 @@ document.addEventListener('DOMContentLoaded', () => {
   const btnNewManual   = document.getElementById('btn-new-manual');
   const btnReset       = document.getElementById('btn-reset');
   const btnReport      = document.getElementById('btn-report');
+  const btnShare       = document.getElementById('btn-share-monitor');
   const reportModal    = document.getElementById('report-modal');
   const reportClose    = document.getElementById('report-close');
   const reportTitle    = document.getElementById('report-title');
   const reportSummary  = document.getElementById('report-summary');
   const reportChartEl  = document.getElementById('report-chart');
+  const shareModal     = document.getElementById('share-modal');
+  const shareClose     = document.getElementById('share-close');
+  const shareQrEl      = document.getElementById('share-qrcode');
 
   // Botão de relatório oculto até haver dados
   btnReport.hidden = true;
@@ -225,6 +229,7 @@ function startBouncingCompanyName(text) {
         currentCall,
         ticketCounter: tc,
         callCounter: cCtr = 0,
+        attendant: attendantId = '',
         cancelledNumbers = [],
         missedNumbers = [],
         attendedNumbers = [],
@@ -249,6 +254,7 @@ function startBouncingCompanyName(text) {
       const cName = ticketNames[currentCall];
       currentCallEl.textContent = currentCall > 0 ? currentCall : '–';
       if (cName) currentCallEl.textContent += ` - ${cName}`;
+      currentIdEl.textContent   = attendantId || '';
       waitingEl.textContent     = waiting;
 
       cancelCountEl.textContent = cancelledCount;
@@ -580,6 +586,15 @@ function startBouncingCompanyName(text) {
     reportClose.onclick = () => { reportModal.hidden = true; };
   }
 
+  /** Exibe QR Code para duplicar monitor */
+  function openShareModal(t) {
+    if (!t || !cfg) return;
+    shareQrEl.innerHTML = '';
+    const url = `${location.origin}/monitor-attendant/?t=${t}&empresa=${encodeURIComponent(cfg.empresa)}&senha=${encodeURIComponent(cfg.senha)}`;
+    new QRCode(shareQrEl, { text: url, width: 256, height: 256 });
+    shareModal.hidden = false;
+  }
+
   /** Inicializa botões e polling */
   function initApp(t) {
     btnNext.onclick = async () => {
@@ -621,6 +636,8 @@ function startBouncingCompanyName(text) {
       refreshAll(t);
     };
     btnReport.onclick = () => openReport(t);
+    btnShare.onclick  = () => openShareModal(t);
+    shareClose.onclick = () => { shareModal.hidden = true; };
     renderQRCode(t);
     refreshAll(t);
     setInterval(() => refreshAll(t), 5000);
@@ -645,12 +662,12 @@ function startBouncingCompanyName(text) {
       return;
     }
 
-    // 2) Se vier ?t e ?empresa na URL, pede só senha
+    // 2) Se vier ?t e ?empresa na URL, solicita senha (ou usa ?senha)
     if (token && empresaParam) {
       loginOverlay.hidden   = true;
       onboardOverlay.hidden = true;
       try {
-        const senhaPrompt = prompt(`Digite a senha de acesso para a empresa ${empresaParam}:`);
+        const senhaPrompt = senhaParam || prompt(`Digite a senha de acesso para a empresa ${empresaParam}:`);
         const res = await fetch(`${location.origin}/.netlify/functions/getMonitorConfig`, {
           method: 'POST',
           headers: {'Content-Type':'application/json'},
@@ -673,10 +690,6 @@ function startBouncingCompanyName(text) {
     onboardOverlay.hidden = false;
     loginOverlay.hidden   = true;
 
-    onboardExisting.onclick = () => {
-      onboardOverlay.hidden = true;
-      loginOverlay.hidden = false;
-    };
 
     loginSubmit.onclick = async () => {
       const empresa = loginCompany.value.trim();


### PR DESCRIPTION
## Summary
- allow duplicating monitor using a QR code with company and password
- add "Duplicar Monitor" button
- show QR in a modal with shareable link
- support automatic login using ?senha parameter
- remove the obsolete "Já tenho monitor" button
- show current attendant identifier on all monitors

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f3e17d900832996bc17e636dee49f