### PR TITLE
Add monitor share QR

### DIFF
--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -494,6 +494,37 @@ body {
   max-width: 100%;
 }
 
+/* Modal para duplicar monitor */
+#share-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+#share-modal[hidden] {
+  display: none !important;
+}
+#share-modal .modal-content {
+  background: #fff;
+  padding: 1rem;
+  border-radius: var(--radius);
+  width: 90%;
+  max-width: 400px;
+  text-align: center;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.3);
+}
+#share-modal .close {
+  float: right;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+#share-qrcode {
+  margin: 1rem auto;
+}
+
 /* Animação de expansão e fade */
 @keyframes ripple-effect {
   to {

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -31,7 +31,6 @@
       <label>Senha de Acesso</label>
       <input id="onboard-password" type="password" placeholder="Defina uma senha" autocomplete="new-password" />
       <button id="onboard-submit">Criar Monitor</button>
-      <button id="onboard-existing" type="button">Já tenho monitor</button>
       <div id="onboard-error" class="error"></div>
     </div>
   </div>
@@ -63,6 +62,9 @@
   </div>
   <button id="btn-delete-config" class="btn btn-secondary">
     Redefinir Cadastro
+  </button>
+  <button id="btn-share-monitor" class="btn btn-secondary">
+    Duplicar Monitor
   </button>
 </header>
 
@@ -143,6 +145,16 @@
         <button id="export-excel" class="btn btn-secondary">Exportar Excel</button>
         <button id="export-pdf" class="btn btn-secondary">Exportar PDF</button>
       </div>
+    </div>
+  </div>
+
+  <!-- Modal de Duplicação do Monitor -->
+  <div id="share-modal" hidden>
+    <div class="modal-content">
+      <span id="share-close" class="close">&times;</span>
+      <h2>Duplicar Monitor</h2>
+      <div id="share-qrcode"></div>
+      <p>Escaneie para abrir este monitor em outro dispositivo.</p>
     </div>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- allow duplicating monitor using a QR code with company and password
- add "Duplicar Monitor" button
- show QR in a modal with shareable link
- support automatic login using ?senha parameter
- remove the obsolete "Já tenho monitor" button
- show current attendant identifier on all monitors
- retry login with company/password if token fails
- fix monitor duplication when an existing config is stored

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f3e17d900832996bc17e636dee49f