### PR TITLE
Support priority tickets in attendant queue

### DIFF
--- a/functions/cancelar.js
+++ b/functions/cancelar.js
@@ -25,6 +25,8 @@ export async function handler(event) {
   await redis.del(prefix + `ticket:${clientId}`);
   if (ticketNum) {
     await redis.srem(prefix + "offHoursSet", String(ticketNum));
+    await redis.lrem(prefix + "priorityQueue", 0, ticketNum);
+    await redis.srem(prefix + "prioritySet", String(ticketNum));
   }
 
   let wait = 0;

--- a/functions/reset.js
+++ b/functions/reset.js
@@ -35,6 +35,8 @@ export async function handler(event) {
     await redis.del(prefix + "attendedSet");
     await redis.del(prefix + "skippedSet");
     await redis.del(prefix + "offHoursSet");
+    await redis.del(prefix + "priorityQueue");
+    await redis.del(prefix + "prioritySet");
     await redis.del(prefix + "ticketNames");
     await redis.del(prefix + "log:entered");
     await redis.del(prefix + "log:called");

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -378,6 +378,8 @@ document.addEventListener('DOMContentLoaded', () => {
   let missedCount    = 0;
   let attendedNums   = [];
   let attendedCount  = 0;
+  let priorityNums   = [];
+  let prioritySet    = new Set();
   let pollingId;
   const fmtTime     = ts => new Date(ts).toLocaleString('pt-BR');
   const msToHms = (ms) => {
@@ -532,7 +534,11 @@ function startBouncingCompanyName(text) {
   /** Atualiza chamada */
   function updateCall(num, attendantId) {
     currentCallNum = num;
-    currentCallEl.textContent = num > 0 ? num : '–';
+    let text = num > 0 ? num : '–';
+    const nm = ticketNames[num];
+    if (nm) text += ` - ${nm}`;
+    if (prioritySet.has(num)) text += ' (Preferencial)';
+    currentCallEl.textContent = text;
     currentIdEl.textContent   = attendantId || '';
   }
 
@@ -554,6 +560,7 @@ function startBouncingCompanyName(text) {
       const li = document.createElement('li');
       const nm = ticketNames[n];
       let text = nm ? `${n} - ${nm}` : String(n);
+      text += prioritySet.has(n) ? ' - Preferencial' : ' - Normal';
       if (offHoursSet.has(n)) text += ' - Fora do horário';
       li.textContent = text;
       queueListEl.appendChild(li);
@@ -589,7 +596,8 @@ function startBouncingCompanyName(text) {
         attendedCount: ac = 0,
         waiting = 0,
         names = {},
-        logoutVersion: srvLogoutVersion = 0
+        logoutVersion: srvLogoutVersion = 0,
+        priorityNumbers = []
       } = await res.json();
 
       if (logoutVersion !== null && srvLogoutVersion !== logoutVersion) {
@@ -611,13 +619,17 @@ function startBouncingCompanyName(text) {
       skippedNums     = skippedNumbers.map(Number);
       offHoursNums    = offHoursNumbers.map(Number);
       offHoursSet     = new Set(offHoursNums);
+      priorityNums    = priorityNumbers.map(Number);
+      prioritySet     = new Set(priorityNums);
       cancelledCount  = cc || cancelledNums.length;
       missedCount     = mc || missedNums.length;
       attendedCount   = ac;
 
       const cName = ticketNames[currentCall];
-      currentCallEl.textContent = currentCall > 0 ? currentCall : '–';
-      if (cName) currentCallEl.textContent += ` - ${cName}`;
+      let cText = currentCall > 0 ? currentCall : '–';
+      if (cName) cText += ` - ${cName}`;
+      if (prioritySet.has(currentCall)) cText += ' (Preferencial)';
+      currentCallEl.textContent = cText;
       currentIdEl.textContent   = attendantId || '';
       waitingEl.textContent     = waiting;
 


### PR DESCRIPTION
## Summary
- Remove cancelled tickets from priority structures and clear them on reset
- Expose priority tickets in status and exclude current call from waiting count
- Show ticket type to attendants for current call and queue entries
- Requeue active ticket when serving a priority number so earlier tickets keep their turn

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5772d4acc832991538bb1a4737e1e