### PR TITLE
Support priority tickets in attendant queue

### DIFF
--- a/functions/cancelar.js
+++ b/functions/cancelar.js
@@ -25,6 +25,8 @@ export async function handler(event) {
   await redis.del(prefix + `ticket:${clientId}`);
   if (ticketNum) {
     await redis.srem(prefix + "offHoursSet", String(ticketNum));
+    await redis.lrem(prefix + "priorityQueue", 0, ticketNum);
+    await redis.srem(prefix + "prioritySet", String(ticketNum));
   }
 
   let wait = 0;

--- a/functions/chamar.js
+++ b/functions/chamar.js
@@ -22,10 +22,29 @@ export async function handler(event) {
     const prefix    = `tenant:${tenantId}:`;
     const paramNum  = url.searchParams.get("num");
     const identifier = url.searchParams.get("id") || "";
+    const currentCallPrev = Number(await redis.get(prefix + "currentCall") || 0);
+    const requeuedPrevKey = prefix + "requeuedPrev";
     const p = paramNum ? null : await redis.lpop(prefix + "priorityQueue");
+    let isPriorityCall = false;
+    if (p) {
+      isPriorityCall = await redis.sismember(prefix + "prioritySet", String(p));
+    }
 
     const counterKey = prefix + "callCounter";
     const prevCounter = Number(await redis.get(counterKey) || 0);
+
+    if (isPriorityCall && currentCallPrev && currentCallPrev !== Number(p)) {
+      const [isCancelled, isMissed, isAttended, isSkipped] = await Promise.all([
+        redis.sismember(prefix + "cancelledSet", String(currentCallPrev)),
+        redis.sismember(prefix + "missedSet", String(currentCallPrev)),
+        redis.sismember(prefix + "attendedSet", String(currentCallPrev)),
+        redis.sismember(prefix + "skippedSet", String(currentCallPrev)),
+      ]);
+      if (!isCancelled && !isMissed && !isAttended && !isSkipped) {
+        await redis.lpush(prefix + "priorityQueue", currentCallPrev);
+        await redis.set(requeuedPrevKey, currentCallPrev);
+      }
+    }
 
     // Próximo a chamar
     let next;
@@ -60,30 +79,37 @@ export async function handler(event) {
     // Quando a chamada é automática (Próximo), quem perde a vez é o último
     // número chamado nessa sequência (prevCounter), independente de haver
     // chamadas manuais entre eles. Assim tickets com ou sem nome são
-    // tratados igualmente.
+    // tratados igualmente. Se o ticket anterior foi reordenado devido a
+    // uma chamada preferencial, ignora esta etapa para evitar cancelamento
+    // indevido.
     if (!paramNum && !p && prevCounter && next > prevCounter) {
-      const [isCancelled, isMissed, isAttended, isSkipped, joinPrev] = await Promise.all([
-        redis.sismember(prefix + "cancelledSet", String(prevCounter)),
-        redis.sismember(prefix + "missedSet", String(prevCounter)),
-        redis.sismember(prefix + "attendedSet", String(prevCounter)),
-        redis.sismember(prefix + "skippedSet", String(prevCounter)),
-        redis.get(prefix + `ticketTime:${prevCounter}`)
-      ]);
-      if (!isCancelled && !isMissed && !isAttended && !isSkipped && joinPrev) {
-        const calledTs = Number((await redis.get(prefix + `calledTime:${prevCounter}`)) || 0);
-        const dur = calledTs ? Date.now() - calledTs : 0;
-        const waitPrev = Number((await redis.get(prefix + `wait:${prevCounter}`)) || 0);
-        await redis.sadd(prefix + "missedSet", String(prevCounter));
-        const missTs = Date.now();
-        // registra o momento em que o ticket perdeu a vez
-        await redis.set(prefix + `cancelledTime:${prevCounter}`, missTs);
-        await redis.lpush(
-          prefix + "log:cancelled",
-          JSON.stringify({ ticket: prevCounter, ts: missTs, reason: "missed", duration: dur, wait: waitPrev })
-        );
-        await redis.ltrim(prefix + "log:cancelled", 0, 999);
-        await redis.expire(prefix + "log:cancelled", LOG_TTL);
-        await redis.del(prefix + `wait:${prevCounter}`);
+      const rqPrev = await redis.get(requeuedPrevKey);
+      if (rqPrev && Number(rqPrev) === prevCounter) {
+        await redis.del(requeuedPrevKey);
+      } else {
+        const [isCancelled, isMissed, isAttended, isSkipped, joinPrev] = await Promise.all([
+          redis.sismember(prefix + "cancelledSet", String(prevCounter)),
+          redis.sismember(prefix + "missedSet", String(prevCounter)),
+          redis.sismember(prefix + "attendedSet", String(prevCounter)),
+          redis.sismember(prefix + "skippedSet", String(prevCounter)),
+          redis.get(prefix + `ticketTime:${prevCounter}`)
+        ]);
+        if (!isCancelled && !isMissed && !isAttended && !isSkipped && joinPrev) {
+          const calledTs = Number((await redis.get(prefix + `calledTime:${prevCounter}`)) || 0);
+          const dur = calledTs ? Date.now() - calledTs : 0;
+          const waitPrev = Number((await redis.get(prefix + `wait:${prevCounter}`)) || 0);
+          await redis.sadd(prefix + "missedSet", String(prevCounter));
+          const missTs = Date.now();
+          // registra o momento em que o ticket perdeu a vez
+          await redis.set(prefix + `cancelledTime:${prevCounter}`, missTs);
+          await redis.lpush(
+            prefix + "log:cancelled",
+            JSON.stringify({ ticket: prevCounter, ts: missTs, reason: "missed", duration: dur, wait: waitPrev })
+          );
+          await redis.ltrim(prefix + "log:cancelled", 0, 999);
+          await redis.expire(prefix + "log:cancelled", LOG_TTL);
+          await redis.del(prefix + `wait:${prevCounter}`);
+        }
       }
     }
 

--- a/functions/reset.js
+++ b/functions/reset.js
@@ -35,6 +35,8 @@ export async function handler(event) {
     await redis.del(prefix + "attendedSet");
     await redis.del(prefix + "skippedSet");
     await redis.del(prefix + "offHoursSet");
+    await redis.del(prefix + "priorityQueue");
+    await redis.del(prefix + "prioritySet");
     await redis.del(prefix + "ticketNames");
     await redis.del(prefix + "log:entered");
     await redis.del(prefix + "log:called");

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -378,6 +378,8 @@ document.addEventListener('DOMContentLoaded', () => {
   let missedCount    = 0;
   let attendedNums   = [];
   let attendedCount  = 0;
+  let priorityNums   = [];
+  let prioritySet    = new Set();
   let pollingId;
   const fmtTime     = ts => new Date(ts).toLocaleString('pt-BR');
   const msToHms = (ms) => {
@@ -532,7 +534,11 @@ function startBouncingCompanyName(text) {
   /** Atualiza chamada */
   function updateCall(num, attendantId) {
     currentCallNum = num;
-    currentCallEl.textContent = num > 0 ? num : '–';
+    let text = num > 0 ? num : '–';
+    const nm = ticketNames[num];
+    if (nm) text += ` - ${nm}`;
+    if (prioritySet.has(num)) text += ' (Preferencial)';
+    currentCallEl.textContent = text;
     currentIdEl.textContent   = attendantId || '';
   }
 
@@ -554,6 +560,7 @@ function startBouncingCompanyName(text) {
       const li = document.createElement('li');
       const nm = ticketNames[n];
       let text = nm ? `${n} - ${nm}` : String(n);
+      text += prioritySet.has(n) ? ' - Preferencial' : ' - Normal';
       if (offHoursSet.has(n)) text += ' - Fora do horário';
       li.textContent = text;
       queueListEl.appendChild(li);
@@ -589,7 +596,8 @@ function startBouncingCompanyName(text) {
         attendedCount: ac = 0,
         waiting = 0,
         names = {},
-        logoutVersion: srvLogoutVersion = 0
+        logoutVersion: srvLogoutVersion = 0,
+        priorityNumbers = []
       } = await res.json();
 
       if (logoutVersion !== null && srvLogoutVersion !== logoutVersion) {
@@ -611,13 +619,17 @@ function startBouncingCompanyName(text) {
       skippedNums     = skippedNumbers.map(Number);
       offHoursNums    = offHoursNumbers.map(Number);
       offHoursSet     = new Set(offHoursNums);
+      priorityNums    = priorityNumbers.map(Number);
+      prioritySet     = new Set(priorityNums);
       cancelledCount  = cc || cancelledNums.length;
       missedCount     = mc || missedNums.length;
       attendedCount   = ac;
 
       const cName = ticketNames[currentCall];
-      currentCallEl.textContent = currentCall > 0 ? currentCall : '–';
-      if (cName) currentCallEl.textContent += ` - ${cName}`;
+      let cText = currentCall > 0 ? currentCall : '–';
+      if (cName) cText += ` - ${cName}`;
+      if (prioritySet.has(currentCall)) cText += ' (Preferencial)';
+      currentCallEl.textContent = cText;
       currentIdEl.textContent   = attendantId || '';
       waitingEl.textContent     = waiting;
 


### PR DESCRIPTION
## Summary
- Remove cancelled tickets from priority structures and clear them on reset
- Expose priority tickets in status and exclude current call from waiting count
- Show ticket type to attendants for current call and queue entries
- Requeue active ticket when serving a priority number so earlier tickets keep their turn
- Skip automatic cancellation of the previous ticket when a priority number interrupts the queue
- Keep requeued tickets from being marked missed after priority calls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5772d4acc832991538bb1a4737e1e