### PR TITLE
Ensure call endpoint only handles pending tickets and client checks own status

### DIFF
--- a/public/client/js/client.js
+++ b/public/client/js/client.js
@@ -259,23 +259,6 @@ async function checkStatus() {
     return;
   }
 
-  if (currentCall > ticketNumber) {
-    const duration = callStartTs ? Date.now() - callStartTs : 0;
-    const res = await safeFetch(`/.netlify/functions/cancelar?t=${tenantId}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ clientId, reason: "missed", duration })
-    });
-    if (!res) return;
-    let msg = "Você perdeu a vez.";
-    try {
-      const data = await res.json();
-      if (data.alreadyAttended) msg = "Atendimento concluído.";
-    } catch {}
-    handleExit(msg);
-    return;
-  }
-
   if (currentCall !== ticketNumber) {
     const cname = names[currentCall];
     statusEl.textContent = cname ? `Chamando: ${currentCall} - ${cname} (${attendant})` : `Chamando: ${currentCall} (${attendant})`;


### PR DESCRIPTION
## Summary
- Refactor `chamar` function to retrieve only pending tickets from preferential and normal queues, updating only the called ticket's metadata.
- Update client status polling to stop marking tickets as lost based on current call number, relying solely on explicit ticket status.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b6152af4688329b9960b56d867a562