### PR TITLE
fix ticket calling when queue has entries

### DIFF
--- a/functions/chamar.js
+++ b/functions/chamar.js
@@ -1,76 +1,86 @@
 import { Redis } from "@upstash/redis";
 
-// Obter hash de um ticket. Garante objeto vazio se inexistente.
-async function getHash(redis, key) {
-  const data = await redis.hgetall(key);
-  return data || {};
-}
-
-// Busca próximo ticket pendente em uma lista, limpando itens inválidos.
-async function pickPendingFromList(redis, prefix, listKey) {
-  let len = await redis.llen(listKey);
-  while (len-- > 0) {
-    const ticketId = await redis.lindex(listKey, 0);
-    if (!ticketId) break;
-    const t = await getHash(redis, `${prefix}:ticket:${ticketId}`);
-    if (t && t.status === 'pending') {
-      await redis.lpop(listKey);
-      return ticketId;
-    }
-    // remove itens que não estão pendentes
-    await redis.lpop(listKey);
-  }
-  return null;
-}
-
-// Atualiza dados de chamada de um ticket.
-async function callTicket(redis, prefix, ticketId) {
-  const key = `${prefix}:ticket:${ticketId}`;
-  const now = Date.now();
-  await redis.hset(key, { status: 'called', called_at: String(now) });
-  await redis.hincrby(key, 'call_count', 1);
-  await redis.set(`${prefix}:last_called_ticket`, ticketId);
-  await redis.lpush(`${prefix}:log:called`, JSON.stringify({ ticketId, ts: now }));
-  return ticketId;
-}
+const LOG_TTL = 60 * 60 * 24 * 30; // 30 days
 
 export async function handler(event) {
   try {
+    const url = new URL(event.rawUrl);
     let body = {};
     if (event.body) {
       try { body = JSON.parse(event.body); } catch {}
     }
-    const { token, ticket_id } = body;
+    const token = body.token || url.searchParams.get("t");
+    const ticketIdParam = body.ticket_id || url.searchParams.get("ticket_id");
+    const identifier = body.identifier || url.searchParams.get("id") || "";
+
     if (!token) {
-      return { statusCode: 400, body: JSON.stringify({ ok: false, error: 'token ausente' }) };
+      return { statusCode: 400, body: JSON.stringify({ ok: false, error: "token ausente" }) };
     }
 
     const redis = Redis.fromEnv();
-    const prefix = `tenant:${token}`;
-    if (ticket_id) {
-      const t = await getHash(redis, `${prefix}:ticket:${ticket_id}`);
-      if (!t || t.status !== 'called') {
-        return { statusCode: 400, body: JSON.stringify({ ok: false, error: 'ticket invalido' }) };
+    const prefix = `tenant:${token}:`;
+
+    if (ticketIdParam) {
+      const ticketId = Number(ticketIdParam);
+      const ts = Date.now();
+      const updateData = {
+        [prefix + "currentCall"]: ticketId,
+        [prefix + "currentCallTs"]: ts,
+        [prefix + `calledTime:${ticketId}`]: ts,
+      };
+      if (identifier) updateData[prefix + "currentAttendant"] = identifier;
+      await redis.mset(updateData);
+      await redis.lpush(
+        prefix + "log:called",
+        JSON.stringify({ ticket: ticketId, attendant: identifier, ts })
+      );
+      await redis.ltrim(prefix + "log:called", 0, 999);
+      await redis.expire(prefix + "log:called", LOG_TTL);
+      return { statusCode: 200, body: JSON.stringify({ ok: true, ticket_id: ticketId }) };
+    }
+
+    const priorityKey = prefix + "priorityQueue";
+    let next = await redis.lpop(priorityKey);
+    if (next) {
+      next = Number(next);
+    } else {
+      const counterKey = prefix + "callCounter";
+      const ticketCounter = Number(await redis.get(prefix + "ticketCounter") || 0);
+      next = Number(await redis.incr(counterKey));
+      while (
+        next <= ticketCounter &&
+        (
+          await redis.sismember(prefix + "cancelledSet", String(next)) ||
+          await redis.sismember(prefix + "missedSet", String(next)) ||
+          await redis.sismember(prefix + "attendedSet", String(next)) ||
+          await redis.sismember(prefix + "skippedSet", String(next))
+        )
+      ) {
+        next = Number(await redis.incr(counterKey));
       }
-      await callTicket(redis, prefix, ticket_id);
-      return { statusCode: 200, body: JSON.stringify({ ok: true, ticket_id }) };
-    }
-    const prefList = `${prefix}:queue:preferential`;
-    const normList = `${prefix}:queue:normal`;
-
-    // 1) preferencial pendente; 2) normal pendente
-    let ticketId = await pickPendingFromList(redis, prefix, prefList);
-    if (!ticketId) ticketId = await pickPendingFromList(redis, prefix, normList);
-
-    if (!ticketId) {
-      return { statusCode: 200, body: JSON.stringify({ ok: true, message: 'Sem tickets pendentes' }) };
+      if (next > ticketCounter) {
+        return { statusCode: 200, body: JSON.stringify({ ok: true, message: "Sem tickets pendentes" }) };
+      }
     }
 
-    await callTicket(redis, prefix, ticketId);
-    return { statusCode: 200, body: JSON.stringify({ ok: true, ticket_id: ticketId }) };
+    const ts = Date.now();
+    const updateData = {
+      [prefix + "currentCall"]: next,
+      [prefix + "currentCallTs"]: ts,
+      [prefix + `calledTime:${next}`]: ts,
+    };
+    if (identifier) updateData[prefix + "currentAttendant"] = identifier;
+    await redis.mset(updateData);
+    await redis.lpush(
+      prefix + "log:called",
+      JSON.stringify({ ticket: next, attendant: identifier, ts })
+    );
+    await redis.ltrim(prefix + "log:called", 0, 999);
+    await redis.expire(prefix + "log:called", LOG_TTL);
+
+    return { statusCode: 200, body: JSON.stringify({ ok: true, ticket_id: next }) };
   } catch (err) {
-    console.error('chamar error', err);
-    return { statusCode: 500, body: JSON.stringify({ ok: false, error: 'Erro interno' }) };
+    console.error("chamar error", err);
+    return { statusCode: 500, body: JSON.stringify({ ok: false, error: "Erro interno" }) };
   }
 }
-

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -1123,19 +1123,32 @@ function startBouncingCompanyName(text) {
     });
 
     btnNext.onclick = async () => {
-      if (currentCallNum > 0 &&
-          !confirm('Ainda há um ticket sendo chamado. Avançar fará com que ele perca a vez. Continuar?')) {
+      if (
+        currentCallNum > 0 &&
+        !confirm(
+          'Ainda há um ticket sendo chamado. Avançar fará com que ele perca a vez. Continuar?'
+        )
+      ) {
         return;
       }
       const id = attendantInput.value.trim();
-      const res = await fetch('/.netlify/functions/chamar', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ token: t })
-      });
-      const data = await res.json();
-      updateCall(Number(data.ticket_id || 0), id);
-      refreshAll(t);
+      try {
+        const res = await fetch('/.netlify/functions/chamar', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token: t })
+        });
+        const data = await res.json();
+        if (!res.ok || !data.ticket_id) {
+          alert(data.error || data.message || 'Sem tickets pendentes');
+          return;
+        }
+        updateCall(Number(data.ticket_id), id);
+        refreshAll(t);
+      } catch (e) {
+        console.error('Erro ao chamar próximo ticket', e);
+        alert('Erro de conexão ao chamar o próximo ticket.');
+      }
     };
     btnRepeat.onclick = async () => {
       if (!currentCallNum) return;


### PR DESCRIPTION
## Summary
- use call counters and priority queue to determine next ticket
- return error only when all numbers are exhausted

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b61ad6b77c8329b4d0791306bfdfef