### PR TITLE
fix: ensure normal and priority calls stay separate

### DIFF
--- a/functions/chamar.js
+++ b/functions/chamar.js
@@ -25,9 +25,12 @@ export async function handler(event) {
     const identifier = url.searchParams.get("id") || "";
     const currentCallPrev = Number(await redis.get(prefix + "currentCall") || 0);
     const requeuedPrevKey = prefix + "requeuedPrev";
-    let p = paramNum ? null : await redis.lpop(prefix + "priorityQueue");
-    if (priorityOnly && !p) {
-      return { statusCode: 404, body: "Sem tickets preferenciais" };
+    let p = null;
+    if (!paramNum && priorityOnly) {
+      p = await redis.lpop(prefix + "priorityQueue");
+      if (!p) {
+        return { statusCode: 404, body: "Sem tickets preferenciais" };
+      }
     }
     let isPriorityCall = priorityOnly;
     if (!isPriorityCall && p) {

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -1143,7 +1143,14 @@ function startBouncingCompanyName(text) {
       const id = attendantInput.value.trim();
       let url = `/.netlify/functions/chamar?t=${t}`;
       if (id) url += `&id=${encodeURIComponent(id)}`;
-      const { called, attendant } = await (await fetch(url)).json();
+      const res = await fetch(url);
+      if (!res.ok) {
+        const msg = await res.text();
+        alert(msg);
+        refreshAll(t);
+        return;
+      }
+      const { called, attendant } = await res.json();
       updateCall(called, attendant);
       refreshAll(t);
     };


### PR DESCRIPTION
## Summary
- prevent `Proximo` from calling preferential tickets by only reading priority queue when `priority=1`
- handle errors when requesting the next normal ticket

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b653e29a0c8329acb7565185267bd9