### PR TITLE
Skip priority tickets on regular next call

### DIFF
--- a/functions/chamar.js
+++ b/functions/chamar.js
@@ -99,13 +99,16 @@ export async function handler(event) {
   }
 
     const ticketCount = Number(await redis.get(prefix + "ticketCounter") || 0);
-    // Se automático, pular tickets cancelados, perdidos ou pulados sem removê-los
+    // Se automático, pular tickets cancelados, perdidos, pulados ou prioritários sem removê-los
     if (!paramNum && (!p || next !== Number(p))) {
       while (
         next <= ticketCount &&
-        ((await redis.sismember(prefix + "cancelledSet", String(next))) ||
-         (await redis.sismember(prefix + "missedSet", String(next))) ||
-         (await redis.sismember(prefix + "skippedSet", String(next))))
+        (
+          (await redis.sismember(prefix + "cancelledSet", String(next))) ||
+          (await redis.sismember(prefix + "missedSet", String(next))) ||
+          (await redis.sismember(prefix + "skippedSet", String(next))) ||
+          (!priorityOnly && (await redis.sismember(prefix + "prioritySet", String(next))))
+        )
       ) {
         next = await redis.incr(counterKey);
       }


### PR DESCRIPTION
## Summary
- Prevent `Proximo` calls from dequeuing preferential tickets by checking the priority set during automatic calls

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b6574a765883298f544f760c14e39f