### PR TITLE
fix: preserve previous ticket on priority call

### DIFF
--- a/functions/chamar.js
+++ b/functions/chamar.js
@@ -42,6 +42,9 @@ export async function handler(event) {
     if (!isPriorityCall && p) {
       isPriorityCall = await redis.sismember(prefix + "prioritySet", String(p));
     }
+    if (!isPriorityCall && paramNum) {
+      isPriorityCall = await redis.sismember(prefix + "prioritySet", String(paramNum));
+    }
 
     const counterKey = prefix + "callCounter";
     const prevCounter = Number(await redis.get(counterKey) || 0);


### PR DESCRIPTION
## Summary
- ensure manual calls detect priority status

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6622d88a88329a78f76f8ce683c55