### PR TITLE
fix: preserve queue on priority call

### DIFF
--- a/functions/chamar.js
+++ b/functions/chamar.js
@@ -42,6 +42,9 @@ export async function handler(event) {
     if (!isPriorityCall && p) {
       isPriorityCall = await redis.sismember(prefix + "prioritySet", String(p));
     }
+    if (!isPriorityCall && paramNum) {
+      isPriorityCall = await redis.sismember(prefix + "prioritySet", String(paramNum));
+    }
 
     const counterKey = prefix + "callCounter";
     const prevCounter = Number(await redis.get(counterKey) || 0);

--- a/public/client/js/client.js
+++ b/public/client/js/client.js
@@ -241,7 +241,7 @@ async function checkStatus() {
   }
   const res = await safeFetch(`/.netlify/functions/status?t=${tenantId}`);
   if (!res) return;
-  const { currentCall, ticketCounter, timestamp, attendant, missedNumbers = [], attendedNumbers = [], names = {} } = await res.json();
+  const { currentCall, callCounter = 0, ticketCounter, timestamp, attendant, missedNumbers = [], attendedNumbers = [], names = {} } = await res.json();
   const myName = names[ticketNumber];
 
   if (ticketCounter < ticketNumber) {
@@ -259,7 +259,7 @@ async function checkStatus() {
     return;
   }
 
-  if (currentCall > ticketNumber) {
+  if (callCounter >= ticketNumber && currentCall !== ticketNumber) {
     const duration = callStartTs ? Date.now() - callStartTs : 0;
     const res = await safeFetch(`/.netlify/functions/cancelar?t=${tenantId}`, {
       method: "POST",


### PR DESCRIPTION
## Summary
- ensure manual calls detect priority status
- prevent earlier tickets from being marked missed during priority calls

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6622d88a88329a78f76f8ce683c55