### PR TITLE
fix: keep normal tickets on priority call

### DIFF
--- a/public/client/js/client.js
+++ b/public/client/js/client.js
@@ -241,7 +241,7 @@ async function checkStatus() {
   }
   const res = await safeFetch(`/.netlify/functions/status?t=${tenantId}`);
   if (!res) return;
-  const { currentCall, ticketCounter, timestamp, attendant, missedNumbers = [], attendedNumbers = [], names = {} } = await res.json();
+  const { currentCall, callCounter = 0, ticketCounter, timestamp, attendant, missedNumbers = [], attendedNumbers = [], names = {} } = await res.json();
   const myName = names[ticketNumber];
 
   if (ticketCounter < ticketNumber) {
@@ -259,7 +259,7 @@ async function checkStatus() {
     return;
   }
 
-  if (currentCall > ticketNumber) {
+  if (callCounter >= ticketNumber && currentCall !== ticketNumber) {
     const duration = callStartTs ? Date.now() - callStartTs : 0;
     const res = await safeFetch(`/.netlify/functions/cancelar?t=${tenantId}`, {
       method: "POST",


### PR DESCRIPTION
## Summary
- ensure priority calls do not advance call counter
- update missed logic to ignore priority calls

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6622d88a88329a78f76f8ce683c55