### PR TITLE
Handle previous priority ticket when new one is called

### DIFF
--- a/functions/atendido.js
+++ b/functions/atendido.js
@@ -53,6 +53,7 @@ export async function handler(event) {
   await redis.mset({
     [prefix + "currentCall"]: 0,
     [prefix + "currentCallTs"]: 0,
+    [prefix + "currentCallPriority"]: 0,
   });
   await redis.del(prefix + "currentAttendant");
 

--- a/functions/reset.js
+++ b/functions/reset.js
@@ -29,6 +29,7 @@ export async function handler(event) {
     await redis.set(prefix + "callCounter",  0);
     await redis.set(prefix + "currentCall",  0);
     await redis.set(prefix + "currentCallTs", ts);
+    await redis.set(prefix + "currentCallPriority", 0);
     await redis.del(prefix + "currentAttendant");
     await redis.del(prefix + "cancelledSet");
     await redis.del(prefix + "missedSet");

--- a/functions/status.js
+++ b/functions/status.js
@@ -47,20 +47,22 @@ export async function handler(event) {
     }
   }
 
-  const [currentCallRaw, callCounterRaw, ticketCounterRaw, attendantRaw, timestampRaw, logoutVersionRaw] =
+  const [currentCallRaw, callCounterRaw, ticketCounterRaw, attendantRaw, timestampRaw, logoutVersionRaw, currentCallPriorityRaw] =
     await redis.mget(
       prefix + "currentCall",
       prefix + "callCounter",
       prefix + "ticketCounter",
       prefix + "currentAttendant",
       prefix + "currentCallTs",
-      prefix + "logoutVersion"
+      prefix + "logoutVersion",
+      prefix + "currentCallPriority"
     );
-  const currentCall   = Number(currentCallRaw || 0);
-  const callCounter   = Number(callCounterRaw || 0);
-  const ticketCounter = Number(ticketCounterRaw || 0);
-  const attendant     = attendantRaw || "";
-  const timestamp     = Number(timestampRaw || 0);
+  const currentCall          = Number(currentCallRaw || 0);
+  const callCounter          = Number(callCounterRaw || 0);
+  const ticketCounter        = Number(ticketCounterRaw || 0);
+  const attendant            = attendantRaw || "";
+  const timestamp            = Number(timestampRaw || 0);
+  const currentCallPriority  = Number(currentCallPriorityRaw || 0);
   const [cancelledList, missedList, attendedList, skippedList, offHoursList, priorityList, nameMap] = await Promise.all([
     redis.smembers(prefix + "cancelledSet"),
     redis.smembers(prefix + "missedSet"),
@@ -130,6 +132,7 @@ export async function handler(event) {
       ticketCounter,
       attendant,
       timestamp,
+      currentCallPriority,
       cancelledCount,
       cancelledNumbers: cancelledNums,
       missedNumbers: missedNums,


### PR DESCRIPTION
## Summary
- mark current priority call as missed if another priority is requested
- track current priority status and expose via status API
- reset priority tracking on attend and reset
- avoid marking current priority as missed when the same ticket is repeated

## Testing
- `node --check functions/chamar.js`
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6e89ec1d883298d210e4580b86ab6