### PR TITLE
Handle current call when queue empty

### DIFF
--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -1147,11 +1147,6 @@ function startBouncingCompanyName(text) {
       if (!res.ok) {
         const msg = await res.text();
         if (currentCallNum > 0 && msg.startsWith('Sem tickets')) {
-          await fetch(`/.netlify/functions/cancelar?t=${t}`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ ticket: currentCallNum, reason: 'missed' })
-          });
           updateCall(0, '');
         }
         alert(msg);
@@ -1174,11 +1169,6 @@ function startBouncingCompanyName(text) {
       if (!res.ok) {
         const msg = await res.text();
         if (currentCallNum > 0 && msg.startsWith('Sem tickets')) {
-          await fetch(`/.netlify/functions/cancelar?t=${t}`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ ticket: currentCallNum, reason: 'missed' })
-          });
           updateCall(0, '');
         }
         alert(msg);


### PR DESCRIPTION
## Summary
- Mark current ticket as "perdeu a vez" in `chamar` when no tickets remain
- Simplify attendant UI error flow to clear current call without extra cancel request

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6f91a41848329b8738561061dd1c3