### PR TITLE
Ensure priority tickets removed when attended

### DIFF
--- a/functions/atendido.js
+++ b/functions/atendido.js
@@ -26,6 +26,7 @@ export async function handler(event) {
 
   const ticketStr = String(ticket);
   await redis.sadd(prefix + "attendedSet", ticketStr);
+  await redis.srem(prefix + "prioritySet", ticketStr);
   await redis.srem(prefix + "cancelledSet", ticketStr);
   await redis.srem(prefix + "missedSet", ticketStr);
 


### PR DESCRIPTION
## Summary
- remove tickets from priority set once attended so numbers reflect current state

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7174589808329b0f5707c7114f4af