### PR TITLE
Remover ticket prioritário da fila ao chamar manualmente

### DIFF
--- a/functions/chamar.js
+++ b/functions/chamar.js
@@ -159,6 +159,9 @@ export async function handler(event) {
         return { statusCode: 400, body: "Ticket não está na fila" };
       }
       await redis.srem(prefix + "skippedSet", String(next));
+      if (isPriorityCall) {
+        await redis.lrem(prefix + "priorityQueue", 0, String(next));
+      }
     } else if (p) {
       while (p) {
         const candidate = Number(p);


### PR DESCRIPTION
## Summary
- Limpa o ticket da `priorityQueue` ao chamá-lo manualmente
- Mantém o ticket em `prioritySet` até ser atendido ou cancelado

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b71c44489083298d5b3323ef620ff2