### PR TITLE
Fix Next Priority alerts to match normal queue behavior

### DIFF
--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -632,8 +632,9 @@ function startBouncingCompanyName(text) {
           !skippedNums.includes(n) &&
           !offHoursNums.includes(n)
         );
-        btnNextPriority.disabled = priorityWaiting.length === 0;
-        btnNextPriority.title = priorityWaiting.length ? '' : 'Sem tickets preferenciais na fila';
+        const hasPriority = priorityWaiting.length > 0 || prioritySet.has(currentCallNum);
+        btnNextPriority.disabled = !hasPriority;
+        btnNextPriority.title = hasPriority ? '' : 'Sem tickets preferenciais na fila';
       }
       cancelledCount  = cc || cancelledNums.length;
       missedCount     = mc || missedNums.length;


### PR DESCRIPTION
## Summary
- Keep "Próximo Preferencial" button enabled when current ticket is priority, applying the same alert rules as "Próximo".

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b72bc465748329831d709a2879df71