### PR TITLE
Display priority label on monitor

### DIFF
--- a/public/monitor/css/monitor.css
+++ b/public/monitor/css/monitor.css
@@ -39,6 +39,12 @@ h1 {
 .number.priority {
   color: #ff9800;
 }
+.priority-label {
+  font-size: 3rem;
+  font-weight: bold;
+  color: #ff9800;
+  margin-top: 0.5rem;
+}
 .name {
   font-size: 2.5rem;
   font-weight: bold;

--- a/public/monitor/index.html
+++ b/public/monitor/index.html
@@ -20,6 +20,7 @@
   <div id="company-name" class="company-name"></div>
     <h1>Chamando</h1>
     <div id="current" class="number">—</div>
+    <div id="priority-label" class="priority-label"></div>
     <div id="current-name" class="name"></div>
     <div id="current-id" class="id-label"></div>
   </div>

--- a/public/monitor/js/monitor.js
+++ b/public/monitor/js/monitor.js
@@ -104,6 +104,7 @@ async function fetchCurrent() {
     const currentEl = document.getElementById('current');
     const nameEl = document.getElementById('current-name');
     const idEl   = document.getElementById('current-id');
+    const priorityEl = document.getElementById('priority-label');
     const container = document.querySelector('.container');
     const name = names[currentCall];
     currentEl.textContent = currentCall;
@@ -114,6 +115,9 @@ async function fetchCurrent() {
     } else {
       currentEl.classList.remove('manual');
       nameEl.textContent = '';
+    }
+    if (priorityEl) {
+      priorityEl.textContent = currentCallPriority > 0 ? 'Preferencial' : '';
     }
     if (idEl) idEl.textContent = attendant || '';
     if (currentCall && (currentCall !== lastCall || timestamp !== lastTs || attendant !== lastId || currentCallPriority !== lastPriority)) {


### PR DESCRIPTION
## Summary
- show "Preferencial" label on monitor when priority ticket is called
- style priority label to highlight preferential calls
- update monitor script to toggle label based on priority

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b75c49d1d88329afc5916b3d2d98cc