### PR TITLE
Include waiting tickets in report

### DIFF
--- a/functions/report.js
+++ b/functions/report.js
@@ -30,6 +30,7 @@ export async function handler(event) {
       redis.hgetall(prefix + "ticketNames"),
       redis.smembers(prefix + "offHoursSet"),
       redis.smembers(prefix + "priorityHistory"),
+      redis.get(prefix + "ticketCounter"),
     ]);
 
     const [
@@ -43,6 +44,7 @@ export async function handler(event) {
       nameMap,
       offHoursSet,
       priorityHistory,
+      ticketCounterRaw,
     ] = data;
 
   const safeParse = (val) => {
@@ -93,6 +95,8 @@ export async function handler(event) {
     }
   }
 
+  const ticketCounter = Number(ticketCounterRaw || 0);
+
   const ticketNumbers = new Set([
     ...entered.map(e => e.ticket),
     ...called.map(c => c.ticket),
@@ -105,6 +109,11 @@ export async function handler(event) {
     ...offHoursNums,
     ...priorityHistory.map(n => Number(n))
   ]);
+
+  for (let i = 1; i <= ticketCounter; i++) {
+    ticketNumbers.add(i);
+  }
+
   const nums = Array.from(ticketNumbers).sort((a, b) => a - b);
 
   const priorityNums = priorityHistory.map(n => Number(n));


### PR DESCRIPTION
## Summary
- ensure report includes all ticket numbers up to current counter so QR-code normal tickets are counted

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b79cdc67d083299216fb3e0dd287c5