### PR TITLE
Replace ticket option icons with SVG

### DIFF
--- a/public/client/css/client.css
+++ b/public/client/css/client.css
@@ -217,20 +217,12 @@ button {
 }
 
 .ticket-option .icon {
-  font-size: 2rem;
   margin-bottom: 0.25rem;
 }
 
-.ticket-option .priority-icon {
-  position: relative;
-  display: inline-block;
-}
-
-.ticket-option .priority-icon .star {
-  position: absolute;
-  font-size: 1rem;
-  top: 0;
-  right: -0.5rem;
+.ticket-option .icon svg {
+  width: 2rem;
+  height: 2rem;
 }
 
 .ticket-option:hover {

--- a/public/client/index.html
+++ b/public/client/index.html
@@ -39,11 +39,23 @@
       <h2>Escolha o tipo de ticket</h2>
       <div class="ticket-options">
         <button class="ticket-option" id="btn-normal">
-          <span class="icon">👤</span>
+          <span class="icon">
+            <svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true">
+              <path d="M12 12a4 4 0 1 0-4-4 4 4 0 0 0 4 4Zm-7.5 8a7.5 7.5 0 0 1 15 0"
+                    fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+            </svg>
+          </span>
           <span>Normal</span>
         </button>
         <button class="ticket-option" id="btn-preferencial">
-          <span class="icon priority-icon">👤<span class="star">⭐</span></span>
+          <span class="icon">
+            <svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true">
+              <path d="M10 10a3 3 0 1 0-3-3 3 3 0 0 0 3 3Zm-5.5 9a5.5 5.5 0 0 1 11 0"
+                    fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+              <path d="M19 5l.9 1.8 2 .3-1.45 1.4.34 2.1L19 9.8l-1.79.9.34-2.1L16.1 7.1l2-.3L19 5Z"
+                    fill="currentColor" />
+            </svg>
+          </span>
           <span>Preferencial</span>
         </button>
       </div>


### PR DESCRIPTION
## Summary
- swap emoji-based Normal and Preferencial ticket buttons for inline SVG icons
- adjust ticket option styles to size SVG icons

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7a5621f54832990428d3a5f152803