### PR TITLE
Refine ticket option buttons

### DIFF
--- a/public/client/css/client.css
+++ b/public/client/css/client.css
@@ -208,29 +208,18 @@ button {
   border: 2px solid var(--primary);
   background: #fff;
   color: var(--primary);
-  padding: 1rem 0.5rem;
+  padding: 0.75rem 0.5rem;
   display: flex;
-  flex-direction: column;
   align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
   border-radius: var(--radius);
   font-size: 1rem;
 }
 
-.ticket-option .icon {
-  font-size: 2rem;
-  margin-bottom: 0.25rem;
-}
-
-.ticket-option .priority-icon {
-  position: relative;
-  display: inline-block;
-}
-
-.ticket-option .priority-icon .star {
-  position: absolute;
-  font-size: 1rem;
-  top: 0;
-  right: -0.5rem;
+.ticket-option .icon svg {
+  width: 1.25rem;
+  height: 1.25rem;
 }
 
 .ticket-option:hover {

--- a/public/client/index.html
+++ b/public/client/index.html
@@ -37,16 +37,20 @@
     <div class="ticket-selection">
       <div class="badge">Aguardando chamada</div>
       <h2>Escolha o tipo de ticket</h2>
-      <div class="ticket-options">
-        <button class="ticket-option" id="btn-normal">
-          <span class="icon">👤</span>
-          <span>Normal</span>
-        </button>
-        <button class="ticket-option" id="btn-preferencial">
-          <span class="icon priority-icon">👤<span class="star">⭐</span></span>
-          <span>Preferencial</span>
-        </button>
-      </div>
+        <div class="ticket-options">
+          <button class="ticket-option" id="btn-normal">
+            <span>Normal</span>
+          </button>
+          <button class="ticket-option" id="btn-preferencial">
+            <span class="icon">
+              <svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true">
+                <path d="M12 17.27l6.18 3.73-1.64-7.03L22 9.24l-7.19-.62L12 2 9.19 8.62 2 9.24l5.46 4.73L5.82 21z"
+                      fill="currentColor" />
+              </svg>
+            </span>
+            <span>Preferencial</span>
+          </button>
+        </div>
       <p class="hint">Toque em uma opção para continuar.</p>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- remove person icons from ticket selection buttons
- show only a star icon for Preferencial option
- adjust button layout and icon sizing for cleaner UI

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7a5621f54832990428d3a5f152803