### PR TITLE
Display ahead-of-you count on client screen

### DIFF
--- a/public/client/css/client.css
+++ b/public/client/css/client.css
@@ -96,10 +96,35 @@ body {
 }
 
 /* Texto “Seu número:” */
+.label-row {
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  gap:8px;
+  white-space:nowrap;
+  margin:8px 0 6px;
+}
 .label {
   font-size: 1rem;
-  color: var(--text);
-  margin-bottom: 0.25rem;
+  color:#475569;
+  margin:0;
+}
+.ahead-pill {
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  background:#f1f5f9;
+  border:1px solid #e2e8f0;
+  color:#334155;
+  border-radius:999px;
+  padding:4px 10px;
+  font-size:12px;
+  font-weight:700;
+  box-shadow:0 4px 12px rgba(15,23,42,.06);
+}
+.ahead-pill svg {
+  width:14px;
+  height:14px;
 }
 
 /* Número do ticket */

--- a/public/client/index.html
+++ b/public/client/index.html
@@ -24,7 +24,18 @@
 
   <main class="container">
     <div class="app-label">xSanNext</div>
-    <p class="label">Seu número:</p>
+    <div class="label-row">
+      <div class="label">Seu número:</div>
+      <div class="ahead-pill" id="aheadPill" title="À sua frente" aria-label="À sua frente">
+        <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path d="M7 8a3 3 0 1 1 6 0 3 3 0 0 1-6 0" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+          <path d="M3 19a6 6 0 0 1 12 0" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+          <path d="M16 9a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+          <path d="M12.5 19a6.5 6.5 0 0 1 9 0" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+        </svg>
+        <span>À sua frente: <b id="aheadCount">0</b></span>
+      </div>
+    </div>
     <div id="ticket" class="ticket">–</div>
     <div id="status" class="status">Aguardando chamada...</div>
     <button id="btn-cancel" class="btn-cancel" disabled>Desistir da fila</button>

--- a/public/client/js/client.js
+++ b/public/client/js/client.js
@@ -232,6 +232,13 @@ async function getTicket(priority = false) {
   sendWelcomeNotification();
 }
 
+function renderAheadCount(value) {
+  const el = document.getElementById('aheadCount');
+  if (!el) { throw new Error('#aheadCount não encontrado'); }
+  const n = Math.max(0, Number(value) || 0);
+  el.textContent = String(n);
+}
+
 async function checkStatus() {
   if (!ticketNumber) return;
   if (!withinSchedule()) {
@@ -242,6 +249,7 @@ async function checkStatus() {
   }
   const res = await safeFetch(`/.netlify/functions/status?t=${tenantId}`);
   if (!res) return;
+  const status = await res.json();
   const {
     currentCall,
     callCounter = 0,
@@ -252,8 +260,10 @@ async function checkStatus() {
     attendedNumbers = [],
     names = {},
     priorityNumbers = [],
-  } = await res.json();
+  } = status;
   const myName = names[ticketNumber];
+  const ahead = status.ahead ?? status.queueAhead ?? status.remaining ?? 0;
+  renderAheadCount(ahead);
 
   if (ticketCounter < ticketNumber) {
     handleExit("Fila reiniciada. Entre novamente.");


### PR DESCRIPTION
## Summary
- show a discrete pill on the client screen with “À sua frente: N” beside “Seu número:”
- style the pill and label row to keep layout inline and compact
- update polling logic to render the ahead-of-you count via `renderAheadCount`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8750718b08329805892eb63a1f9b6