### PR TITLE
style: use black for admin panel labels

### DIFF
--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -764,6 +764,10 @@ body {
   margin-bottom: 0.75rem;
 }
 
+.admin-panel .admin-section h4 {
+  color: #000;
+}
+
 .admin-panel .pref-toggle {
   display: flex;
   align-items: center;
@@ -772,6 +776,7 @@ body {
 
 .admin-panel .pref-toggle label {
   font-weight: 500;
+  color: #000;
 }
 
 .admin-panel .ticket-setter label {


### PR DESCRIPTION
## Summary
- ensure admin panel section headings render in black
- set preference toggle labels to black for visibility

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8925623c48329bd223f52de3e47fe