### PR TITLE
Fix ahead count for normal tickets without preferential desk

### DIFF
--- a/public/client/js/client.js
+++ b/public/client/js/client.js
@@ -297,11 +297,6 @@ async function checkStatus() {
     for (let n = callCounter + 1; n < ticketNumber; n++) {
       if (n !== currentCall && !removed.has(n)) ahead++;
     }
-    if (!isPriority) {
-      for (const pn of priNums) {
-        if (pn >= ticketNumber && !removed.has(pn)) ahead++;
-      }
-    }
   }
   renderAheadCount(ahead, label);
 


### PR DESCRIPTION
## Summary
- ensure normal tickets aren't counted behind priority tickets when no preferential desk

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b896c695348329817395fe098f8510