### PR TITLE
Display separate waiting counts for normal and priority clients

### DIFF
--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -301,6 +301,26 @@ body {
 .status-info {
   font-size: 1rem;
   color: var(--muted);
+  text-align: center;
+}
+
+.waiting-details {
+  margin-top: 0.25rem;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  font-size: 0.875rem;
+}
+
+.waiting-details .badge {
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius);
+  background: #e0e0e0;
+}
+
+.waiting-details .badge.priority {
+  background: var(--warning);
+  color: #fff;
 }
 
 .history-panel h2 {

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -162,7 +162,11 @@
         <button id="btn-new-priority" class="btn btn-warning">Ticket Preferencial</button>
       </div>
       <div class="status-info">
-        Em espera: <span id="waiting-count">–</span> clientes
+        <span class="waiting-total">Em espera: <span id="waiting-count">–</span> clientes</span>
+        <div class="waiting-details">
+          <span class="badge normal">Normais: <span id="waiting-normal">0</span></span>
+          <span class="badge priority">Preferenciais: <span id="waiting-priority">0</span></span>
+        </div>
       </div>
       <div class="btn-row">
         <button id="btn-reset" class="btn btn-warning">Resetar Tickets</button>

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -137,6 +137,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const currentCallEl  = document.getElementById('current-call');
   const currentIdEl    = document.getElementById('current-id');
   const waitingEl      = document.getElementById('waiting-count');
+  const waitingNormalEl   = document.getElementById('waiting-normal');
+  const waitingPriorityEl = document.getElementById('waiting-priority');
   const cancelListEl   = document.getElementById('cancel-list');
   const cancelThumbsEl = document.getElementById('cancel-thumbs');
   const cancelCountEl  = document.getElementById('cancel-count');
@@ -654,19 +656,23 @@ function startBouncingCompanyName(text) {
       offHoursSet     = new Set(offHoursNums);
       priorityNums    = priorityNumbers.map(Number);
       prioritySet     = new Set(priorityNums);
+      const priorityWaiting = priorityNums.filter(n =>
+        n !== currentCallNum &&
+        !cancelledNums.includes(n) &&
+        !missedNums.includes(n) &&
+        !attendedNums.includes(n) &&
+        !skippedNums.includes(n) &&
+        !offHoursNums.includes(n)
+      );
       if (btnNextPriority) {
-        const priorityWaiting = priorityNums.filter(n =>
-          n !== currentCallNum &&
-          !cancelledNums.includes(n) &&
-          !missedNums.includes(n) &&
-          !attendedNums.includes(n) &&
-          !skippedNums.includes(n) &&
-          !offHoursNums.includes(n)
-        );
         const hasPriority = priorityWaiting.length > 0 || prioritySet.has(currentCallNum);
         btnNextPriority.disabled = !hasPriority;
         btnNextPriority.title = hasPriority ? '' : 'Sem tickets preferenciais na fila';
       }
+      const waitingPriority = priorityWaiting.length;
+      const waitingNormal = Math.max(0, waiting - waitingPriority);
+      waitingPriorityEl.textContent = waitingPriority;
+      waitingNormalEl.textContent = waitingNormal;
       cancelledCount  = cc || cancelledNums.length;
       missedCount     = mc || missedNums.length;
       attendedCount   = ac;


### PR DESCRIPTION
## Summary
- show total, normal, and priority waiting counts on attendant panel
- calculate waiting breakdown in monitor-attendant script
- style waiting count badges for clearer UI

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b89ace54688329920da044595022ef