### PR TITLE
refactor: redesign attendant panel layout

### DIFF
--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -242,11 +242,15 @@ body {
   color: var(--primary);
   margin-bottom: 0.5rem;
 }
-.display {
-  font-size: 1.5rem;
-  margin-bottom: 0.75rem;
+.queue-summary {
+  text-align: center;
+  margin-bottom: 1rem;
 }
-#current-call {
+.queue-summary .calling {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+#calling {
   font-weight: bold;
   color: var(--secondary);
 }
@@ -255,30 +259,75 @@ body {
   font-size: 1rem;
   color: var(--muted);
 }
+.queue-summary .waiting {
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+}
+.queue-summary .chips {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+}
+.queue-summary .chip {
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius);
+  background: #e0e0e0;
+}
+.queue-summary .chip.pref {
+  background: var(--warning);
+}
 
 .btn {
   width: 100%;
-  padding: 1rem;
-  margin-bottom: 0.5rem;
-  font-size: 1.1rem;
+  min-height: 64px;
+  padding: 0.75rem 1rem;
+  font-size: 18px;
   border: none;
-  border-radius: var(--radius);
+  border-radius: 14px;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
   transition: background 0.2s;
 }
-
-.btn-row {
-  display: flex;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
+.btn svg {
+  width: 24px;
+  height: 24px;
 }
-
-.btn-row .btn {
-  margin-bottom: 0;
-  flex: 1;
+.btn:focus {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 .btn-primary {
   background: var(--secondary);
+  color: #fff;
+}
+.btn-success {
+  background: var(--success);
+  color: #fff;
+}
+.btn-preferential {
+  background: var(--warning);
+  color: #333;
+}
+.btn-ghost {
+  background: #fff;
+  color: var(--text);
+  border: 2px solid #ddd;
+}
+.btn-outline {
+  background: #fff;
+  color: var(--text);
+  border: 2px solid var(--text);
+}
+.btn-danger {
+  background: var(--danger);
   color: #fff;
 }
 .btn-secondary {
@@ -289,33 +338,18 @@ body {
   background: var(--warning);
   color: #333;
 }
-.btn-success {
-  background: var(--success);
-  color: #fff;
-}
-.btn-warning:hover {
-  background: #f2a100;
-}
 
-
-.status-info {
-  font-size: 1rem;
-  color: var(--muted);
-  text-align: center;
-}
-
-.waiting-details {
-  margin-top: 0.25rem;
-  display: flex;
+.btn-grid,
+.footer-buttons {
+  display: grid;
+  grid-template-columns: 1fr;
   gap: 0.5rem;
-  justify-content: center;
-  font-size: 0.875rem;
 }
-
-.waiting-details .badge {
-  padding: 0.25rem 0.5rem;
-  border-radius: var(--radius);
-  background: #e0e0e0;
+@media (min-width: 480px) {
+  .btn-grid,
+  .footer-buttons {
+    grid-template-columns: 1fr 1fr;
+  }
 }
 
 .waiting-details .badge.priority {

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -145,32 +145,49 @@
 
     <!-- Painel de Chamada -->
     <section class="call-panel">
-      <div class="display">
-        Chamando: <span id="current-call">–</span>
-        <small id="current-id" class="id-label"></small>
-      </div>
-      <div class="btn-row">
-        <button id="btn-next" class="btn btn-primary">Próximo</button>
-        <button id="btn-next-priority" class="btn btn-warning">Próximo Preferencial</button>
-      </div>
-      <div class="btn-row">
-        <button id="btn-repeat" class="btn btn-secondary">Repetir</button>
-        <button id="btn-attended" class="btn btn-success">Atendido</button>
-      </div>
-      <div class="btn-row">
-        <button id="btn-new-manual" class="btn btn-secondary">Ticket</button>
-        <button id="btn-new-priority" class="btn btn-warning">Ticket Preferencial</button>
-      </div>
-      <div class="status-info">
-        <span class="waiting-total">Em espera: <span id="waiting-count">–</span> clientes</span>
-        <div class="waiting-details">
-          <span class="badge normal">Normais: <span id="waiting-normal">0</span></span>
-          <span class="badge priority">Preferenciais: <span id="waiting-priority">0</span></span>
+      <div class="queue-summary">
+        <div class="calling">Chamando: <span id="calling">–</span><small id="current-id" class="id-label"></small></div>
+        <div class="waiting">Em espera: <span id="qTotal">–</span> clientes</div>
+        <div class="chips">
+          <span class="chip normal">Normais: <span id="qNorm">0</span></span>
+          <span class="chip pref">Preferenciais: <span id="qPref">0</span></span>
         </div>
       </div>
-      <div class="btn-row">
-        <button id="btn-reset" class="btn btn-warning">Resetar Tickets</button>
-        <button id="btn-report" class="btn btn-secondary">Relatório</button>
+      <div class="btn-grid">
+        <button id="btn-next" class="btn btn-primary" aria-label="Chamar próximo ticket" title="Chamar próximo ticket">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          <span>Próximo</span>
+        </button>
+        <button id="btn-next-pref" class="btn btn-preferential" aria-label="Chamar próximo ticket preferencial" title="Chamar próximo ticket preferencial">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/><path d="M5 3l2 4 4 .5-3 3 1 4-4-2-4 2 1-4-3-3 4-.5z" fill="currentColor"/></svg>
+          <span>Próximo Preferencial</span>
+        </button>
+        <button id="btn-repeat" class="btn btn-ghost" aria-label="Repetir chamada" title="Repetir chamada">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 4v6h6M20 20v-6h-6" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/><path d="M20 9A8 8 0 1 0 4 15" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          <span>Repetir</span>
+        </button>
+        <button id="btn-done" class="btn btn-success" aria-label="Marcar como atendido" title="Marcar como atendido">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 13l4 4L19 7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          <span>Atendido</span>
+        </button>
+        <button id="btn-ticket" class="btn btn-ghost" aria-label="Gerar ticket" title="Gerar ticket">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 7h18v10H3z" stroke="currentColor" stroke-width="2" fill="none"/><path d="M8 7v10M16 7v10M3 12h18" stroke="currentColor" stroke-width="2" fill="none"/></svg>
+          <span>Ticket</span>
+        </button>
+        <button id="btn-ticket-pref" class="btn btn-preferential" aria-label="Gerar ticket preferencial" title="Gerar ticket preferencial">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 7h18v10H3z" stroke="currentColor" stroke-width="2" fill="none"/><path d="M8 7v10M16 7v10M3 12h18" stroke="currentColor" stroke-width="2" fill="none"/><path d="M5 2l1.5 3 3 .4-2.2 2.2.5 3-2.8-1.5-2.8 1.5.5-3L0 5.4l3-.4z" fill="currentColor"/></svg>
+          <span>Ticket Preferencial</span>
+        </button>
+      </div>
+      <div class="footer-buttons">
+        <button id="btn-report" class="btn btn-outline" aria-label="Gerar relatório" title="Gerar relatório">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 3h18v18H3z" stroke="currentColor" stroke-width="2" fill="none"/><path d="M7 13l3 3 7-7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          <span>Relatório</span>
+        </button>
+        <button id="btn-reset" class="btn btn-danger" aria-label="Resetar tickets" title="Resetar tickets">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M8 6v14h8V6" stroke="currentColor" stroke-width="2" fill="none" stroke-linejoin="round"/><path d="M10 6V4h4v2" stroke="currentColor" stroke-width="2" fill="none" stroke-linejoin="round"/></svg>
+          <span>Resetar Tickets</span>
+        </button>
       </div>
     </section>
 

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -134,11 +134,11 @@ document.addEventListener('DOMContentLoaded', () => {
   if (attParam) {
     attendantInput.value = attParam;
   }
-  const currentCallEl  = document.getElementById('current-call');
+  const callingEl      = document.getElementById('calling');
   const currentIdEl    = document.getElementById('current-id');
-  const waitingEl      = document.getElementById('waiting-count');
-  const waitingNormalEl   = document.getElementById('waiting-normal');
-  const waitingPriorityEl = document.getElementById('waiting-priority');
+  const qTotalEl       = document.getElementById('qTotal');
+  const qNormEl        = document.getElementById('qNorm');
+  const qPrefEl        = document.getElementById('qPref');
   const cancelListEl   = document.getElementById('cancel-list');
   const cancelThumbsEl = document.getElementById('cancel-thumbs');
   const cancelCountEl  = document.getElementById('cancel-count');
@@ -150,11 +150,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const attendedCountEl  = document.getElementById('attended-count');
   const queueListEl    = document.getElementById('queue-list');
   const btnNext        = document.getElementById('btn-next');
-  const btnNextPriority= document.getElementById('btn-next-priority');
+  const btnNextPref    = document.getElementById('btn-next-pref');
   const btnRepeat      = document.getElementById('btn-repeat');
-  const btnAttended    = document.getElementById('btn-attended');
-  const btnNewManual   = document.getElementById('btn-new-manual');
-  const btnNewPriority = document.getElementById('btn-new-priority');
+  const btnDone        = document.getElementById('btn-done');
+  const btnTicket      = document.getElementById('btn-ticket');
+  const btnTicketPref  = document.getElementById('btn-ticket-pref');
   const btnReset       = document.getElementById('btn-reset');
   const btnReport      = document.getElementById('btn-report');
   const btnView        = document.getElementById('btn-view-monitor');
@@ -572,7 +572,7 @@ function startBouncingCompanyName(text) {
     const nm = ticketNames[num];
     if (nm) text += ` - ${nm}`;
     if (prioritySet.has(num)) text += ' (Preferencial)';
-    currentCallEl.textContent = text;
+    callingEl.textContent = text;
     currentIdEl.textContent   = attendantId || '';
   }
 
@@ -664,15 +664,20 @@ function startBouncingCompanyName(text) {
         !skippedNums.includes(n) &&
         !offHoursNums.includes(n)
       );
-      if (btnNextPriority) {
+      if (btnNextPref) {
         const hasPriority = priorityWaiting.length > 0 || prioritySet.has(currentCallNum);
-        btnNextPriority.disabled = !hasPriority;
-        btnNextPriority.title = hasPriority ? '' : 'Sem tickets preferenciais na fila';
+        btnNextPref.disabled = !hasPriority;
+        btnNextPref.title = hasPriority ? '' : 'Sem tickets preferenciais na fila';
       }
       const waitingPriority = priorityWaiting.length;
       const waitingNormal = Math.max(0, waiting - waitingPriority);
-      waitingPriorityEl.textContent = waitingPriority;
-      waitingNormalEl.textContent = waitingNormal;
+      if (btnNext) {
+        const hasAny = waitingPriority + waitingNormal > 0;
+        btnNext.disabled = !hasAny;
+        btnNext.title = hasAny ? '' : 'Sem tickets na fila';
+      }
+      qPrefEl.textContent = waitingPriority;
+      qNormEl.textContent = waitingNormal;
       cancelledCount  = cc || cancelledNums.length;
       missedCount     = mc || missedNums.length;
       attendedCount   = ac;
@@ -681,9 +686,9 @@ function startBouncingCompanyName(text) {
       let cText = currentCall > 0 ? currentCall : '–';
       if (cName) cText += ` - ${cName}`;
       if (prioritySet.has(currentCall)) cText += ' (Preferencial)';
-      currentCallEl.textContent = cText;
+      callingEl.textContent = cText;
       currentIdEl.textContent   = attendantId || '';
-      waitingEl.textContent     = waiting;
+      qTotalEl.textContent     = waiting;
 
       cancelCountEl.textContent = cancelledCount;
       cancelThumbsEl.innerHTML  = '';
@@ -820,7 +825,7 @@ function startBouncingCompanyName(text) {
     const attendedCount  = Number(attendedCountEl.textContent) || 0;
     const cancelledCount = Number(cancelCountEl.textContent) || 0;
     const missedCount    = Number(missedCountEl.textContent) || 0;
-    const waitingCount   = Number(waitingEl.textContent) || 0;
+    const waitingCount   = Number(qTotalEl.textContent) || 0;
 
     if (!tickets.length &&
         !totalTickets &&
@@ -1215,7 +1220,7 @@ function startBouncingCompanyName(text) {
       updateCall(called, attendant);
       refreshAll(t);
     };
-    btnNextPriority.onclick = async () => {
+    btnNextPref.onclick = async () => {
       if (currentCallNum > 0) {
         if (!prioritySet.has(currentCallNum)) {
           alert('Finalize o ticket normal antes de chamar o próximo preferencial.');
@@ -1250,7 +1255,7 @@ function startBouncingCompanyName(text) {
       updateCall(called, attendant);
       refreshAll(t);
     };
-    btnAttended.onclick = async () => {
+    btnDone.onclick = async () => {
       if (!currentCallNum) return;
       await fetch(`/.netlify/functions/atendido?t=${t}`, {
         method: 'POST',
@@ -1259,7 +1264,7 @@ function startBouncingCompanyName(text) {
       });
       refreshAll(t);
     };
-    btnNewManual.onclick = async () => {
+    btnTicket.onclick = async () => {
       const name = prompt('Nome do cliente:');
       if (!name) return;
       await fetch(`/.netlify/functions/manualTicket?t=${t}`, {
@@ -1269,7 +1274,7 @@ function startBouncingCompanyName(text) {
       });
       refreshAll(t);
     };
-    btnNewPriority.onclick = async () => {
+    btnTicketPref.onclick = async () => {
       const name = prompt('Nome do cliente:');
       if (!name) return;
       await fetch(`/.netlify/functions/manualTicket?t=${t}`, {


### PR DESCRIPTION
## Summary
- redesign attendant panel with mobile-first grid and queue summary
- update button styles, icons, and accessibility
- maintain handlers with new IDs and disable logic

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8a37bfc7483298a91d49810fb6c73