### PR TITLE
fix: show revogar only for clone attendants

### DIFF
--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -17,12 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let senhaParam      = urlParams.get('senha');
   let attParam        = urlParams.get('a');
   let cloneSeq       = urlParams.get('n');
-  let isClone         = urlParams.get('clone') === '1' || localStorage.getItem('isClone') === '1';
-  if (isClone) {
-    localStorage.setItem('isClone', '1');
-  } else {
-    localStorage.removeItem('isClone');
-  }
+  const isClone       = urlParams.get('clone') === '1';
   const storedConfig  = localStorage.getItem('monitorConfig');
   let cfg             = storedConfig ? JSON.parse(storedConfig) : null;
   if (cfg && typeof cfg.preferentialDesk === 'undefined') {


### PR DESCRIPTION
## Summary
- ensure 'Revogar' button only appears on clone attendant links

## Testing
- npm test (fails: Missing script "test")
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68b8a9a9c8848329b48ea9fa1dde0da6