### PR TITLE
feat: show active clones on admin

### DIFF
--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -158,6 +158,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const btnRevokeClone = document.getElementById('clone-revoke');
   const adminToggle    = document.getElementById('admin-toggle');
   const adminPanel     = document.getElementById('admin-panel');
+  const cloneListEl    = document.getElementById('clone-list');
   const nextTicketInput= document.getElementById('next-ticket');
   const lastTicketSpan = document.getElementById('last-ticket');
   const setTicketBtn   = document.getElementById('set-ticket');
@@ -1148,14 +1149,29 @@ function startBouncingCompanyName(text) {
   }
 
   async function loadCloneList(t) {
-    if (!t || !isClone) return;
+    if (!t) return;
     try {
       const res = await fetch(`/.netlify/functions/listClones?t=${t}`);
       const { clones = [] } = await res.json();
-      if (!clones.includes(cloneId)) {
-        localStorage.clear();
-        history.replaceState(null, '', '/');
-        location.href = '/';
+      if (isClone) {
+        if (!clones.includes(cloneId)) {
+          localStorage.clear();
+          history.replaceState(null, '', '/');
+          location.href = '/';
+        }
+      } else if (clonesPanel && cloneListEl) {
+        const others = clones.filter(c => c !== cloneId);
+        cloneListEl.innerHTML = '';
+        clonesPanel.hidden = others.length === 0;
+        others.forEach((id, idx) => {
+          const li = document.createElement('li');
+          const btn = document.createElement('button');
+          btn.className = 'btn btn-secondary';
+          btn.textContent = `Revogar ${idx + 1}`;
+          btn.onclick = () => revokeClone(t, id);
+          li.appendChild(btn);
+          cloneListEl.appendChild(li);
+        });
       }
     } catch (e) {
       console.error('listClones', e);


### PR DESCRIPTION
## Summary
- display active clones in admin panel with sequential numbering and revoke buttons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8b4f59e108329a02880adfe344372