### PR TITLE
fix: hide revoke button for primary attendant

### DIFF
--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -22,14 +22,13 @@ document.addEventListener('DOMContentLoaded', () => {
     sessionStorage.setItem('cloneId', cloneId);
   }
   const cloneSeqKey   = `cloneSeq_${cloneId}`;
+  const isCloneParam  = urlParams.get('clone') === '1';
   let cloneSeq        = null;
-  if (urlParams.get('clone') === '1') {
+  if (isCloneParam) {
     cloneSeq = urlParams.get('n') || localStorage.getItem(cloneSeqKey);
     if (cloneSeq) localStorage.setItem(cloneSeqKey, cloneSeq);
-  } else {
-    cloneSeq = localStorage.getItem(cloneSeqKey);
   }
-  const isClone       = cloneSeq !== null;
+  const isClone       = isCloneParam;
   const storedConfig  = localStorage.getItem('monitorConfig');
   let cfg             = storedConfig ? JSON.parse(storedConfig) : null;
   if (cfg && typeof cfg.preferentialDesk === 'undefined') {


### PR DESCRIPTION
## Summary
- ensure Revogar button appears only for clone attendants

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8dd8cc0048329a412137abfb4d494