### PR TITLE
Show revoke button only when config hidden

### DIFF
--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -246,15 +246,19 @@ document.addEventListener('DOMContentLoaded', () => {
     if (btnChangePw)     btnChangePw.hidden = true;
     if (adminToggle)     { adminToggle.remove(); }
     if (adminPanel)      { adminPanel.remove(); }
-    if (btnRevokeClone) {
-      btnRevokeClone.hidden = false;
-      if (cloneSeq) btnRevokeClone.textContent = `Revogar${cloneSeq}`;
-      btnRevokeClone.onclick = () => revokeClone(token, cloneId);
-    }
     const qrPanel = document.querySelector('.qrcode-panel');
     if (qrPanel) qrPanel.style.display = 'none';
-  } else if (btnRevokeClone) {
-    btnRevokeClone.hidden = true;
+  }
+  if (btnRevokeClone) {
+    const adminBtn = document.getElementById('admin-toggle');
+    const adminVisible = adminBtn && !adminBtn.hidden;
+    btnRevokeClone.hidden = adminVisible;
+    if (!btnRevokeClone.hidden) {
+      if (cloneSeq) btnRevokeClone.textContent = `Revogar${cloneSeq}`;
+      btnRevokeClone.onclick = () => revokeClone(token, cloneId);
+    } else {
+      btnRevokeClone.onclick = null;
+    }
   }
 
   btnEditSchedule.onclick = () => {


### PR DESCRIPTION
## Summary
- Tie the Revogar clone button visibility to the configuration button presence
- Hide Revogar when configuration is available to the attendant

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b8e0d1dfb8832981d56e29ec4f8b8b