### PR TITLE
Move QR code to header with PDF export

### DIFF
--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -183,23 +183,6 @@ body {
   display: block;
 }
 
-/* Layout and buttons styling as before */
-.header {
-  background: var(--primary);
-  color: #fff;
-  padding: 1rem;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-.logo {
-  font-size: 1.5rem;
-  font-weight: bold;
-}
-.user {
-  font-size: 1rem;
-}
-
 .header-schedule {
   margin-left: 0.5rem;
   font-size: 0.75rem;
@@ -441,20 +424,14 @@ body {
 #login-overlay[hidden] {
   display: none !important;
 }
-.header {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 1rem;
-}
-
 /* Header principal */
 .header {
   display: flex;
   align-items: center;
-  justify-content: space-between; /* Logo à esquerda, botão à direita */
   padding: 0.75rem 1rem;
   background-color: #005a9c;
+  color: #fff;
+  gap: 0.75rem;
 }
 
 /* Contêiner da logo + textos */
@@ -462,6 +439,7 @@ body {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  flex: 1;
 }
 
 .logo-icon {
@@ -469,13 +447,6 @@ body {
   height: 24px;
   flex-shrink: 0;
 }
-
-.logo-container {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
 
 /* Bloco de textos (SanNext + empresa) */
 .logo-texts {
@@ -774,8 +745,7 @@ body {
 
 /* Botão de PDF do QR Code */
 .qrcode-wrapper {
-  display: inline-flex;
-  flex-direction: column;
+  display: flex;
   align-items: center;
   gap: 0.5rem;
 }
@@ -785,6 +755,21 @@ body {
   padding: 0.25rem 0.5rem;
   font-size: 0.8rem;
   margin-bottom: 0;
+}
+
+/* QR Code no cabeçalho */
+.header .qrcode-wrapper #qrcode canvas,
+.header .qrcode-wrapper #qrcode img {
+  width: 64px;
+  height: 64px;
+}
+
+@media (min-width: 600px) {
+  .header .qrcode-wrapper #qrcode canvas,
+  .header .qrcode-wrapper #qrcode img {
+    width: 96px;
+    height: 96px;
+  }
 }
 
 /* Painel administrativo lateral */
@@ -914,10 +899,6 @@ body {
 
 .admin-panel[hidden] {
   display: none;
-}
-
-#admin-toggle {
-  margin-left: auto;
 }
 
 #clone-revoke {

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -87,6 +87,10 @@
     </div>
   </div>
   <button id="admin-toggle" class="btn btn-secondary" aria-label="Administração">⚙️</button>
+  <div class="qrcode-wrapper">
+    <div id="qrcode"></div>
+    <button id="btn-qr-pdf" class="btn btn-secondary" hidden>PDF</button>
+  </div>
   <nav id="admin-panel" class="admin-panel" hidden>
     <h3>Administração</h3>
     <div class="ticket-setter admin-section">
@@ -126,16 +130,6 @@
 
   <!-- Conteúdo Principal -->
   <main class="main" hidden>
-    <!-- Seção de QR Code -->
-    <section class="qrcode-panel">
-      <h2>QR Code</h2>
-      <div class="qrcode-wrapper">
-        <div id="qrcode"></div>
-        <button id="btn-qr-pdf" class="btn btn-secondary" hidden>PDF</button>
-      </div>
-      <p>Aponte a câmera do celular para este QR para entrar na fila.</p>
-    </section>
-
     <!-- Painel de Identificador -->
     <section class="id-panel">
       <label for="attendant-id">Identificador:</label>

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -245,8 +245,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (btnChangePw)     btnChangePw.hidden = true;
     if (adminToggle)     { adminToggle.remove(); }
     if (adminPanel)      { adminPanel.remove(); }
-    const qrPanel = document.querySelector('.qrcode-panel');
-    if (qrPanel) qrPanel.style.display = 'none';
+    const qrWrapper = document.querySelector('.qrcode-wrapper');
+    if (qrWrapper) qrWrapper.style.display = 'none';
   }
 
   btnEditSchedule.onclick = () => {
@@ -377,22 +377,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const btnQrPdf      = document.getElementById('btn-qr-pdf');
   let currentClientUrl = '';
-  let qrReady = false;
 
-  function updatePdfBtnVisibility() {
-    if (!qrReady) {
-      btnQrPdf.hidden = true;
-      return;
-    }
-    const rect = qrContainer.getBoundingClientRect();
-    const inView = rect.bottom > 0 && rect.top < window.innerHeight;
-    btnQrPdf.hidden = !inView;
-  }
-
-  window.addEventListener('scroll', updatePdfBtnVisibility);
-  window.addEventListener('resize', updatePdfBtnVisibility);
   btnQrPdf.addEventListener('click', generateQrPdf);
-  updatePdfBtnVisibility();
 
   let currentCallNum = 0; // último número chamado exibido
   let ticketNames    = {};
@@ -423,16 +409,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
  /** Renderiza o QR Code e configura interação */
 function renderQRCode(tId) {
-  qrContainer.innerHTML = '';
-  qrOverlayContent.innerHTML = '';
+    qrContainer.innerHTML = '';
+    qrOverlayContent.innerHTML = '';
 
-  const urlCliente = `${location.origin}/client/?t=${tId}&empresa=${encodeURIComponent(cfg.empresa)}`;
-  new QRCode(qrContainer,     { text: urlCliente, width: 128, height: 128 });
-  new QRCode(qrOverlayContent, { text: urlCliente, width: 256, height: 256 });
+    const urlCliente = `${location.origin}/client/?t=${tId}&empresa=${encodeURIComponent(cfg.empresa)}`;
+    new QRCode(qrContainer,     { text: urlCliente, width: 128, height: 128 });
+    new QRCode(qrOverlayContent, { text: urlCliente, width: 256, height: 256 });
 
-  currentClientUrl = urlCliente;
-  qrReady = true;
-  updatePdfBtnVisibility();
+    currentClientUrl = urlCliente;
+    btnQrPdf.hidden = false;
 
   qrContainer.style.cursor = 'pointer';
   qrContainer.onclick = () =>
@@ -494,7 +479,7 @@ function generateQrPdf() {
         <h1>${cfg.empresa || ''}</h1>
         <h2>Entre na fila</h2>
         <img src="${qrDataUrl}" alt="QR Code" style="width:200px;height:200px;" />
-        <p>1. Abra a câmera do seu celular.<br>2. Aponte para o QR code.<br>3. Siga o link para pegar sua senha.</p>
+        <p>1. Abra a câmera do seu celular.<br>2. Siga o link para pegar sua senha.</p>
         <p>${currentClientUrl}</p>
       </body>
       </html>`;
@@ -520,16 +505,14 @@ function generateQrPdf() {
   doc.text('Entre na fila', pageWidth / 2, y, { align: 'center' });
   y += 10;
   doc.addImage(qrDataUrl, 'PNG', pageWidth / 2 - 35, y, 70, 70);
-  y += 80;
-  doc.setFontSize(12);
-  doc.text('1. Abra a câmera do seu celular.', pageWidth / 2, y, { align: 'center' });
-  y += 6;
-  doc.text('2. Aponte para o QR code.', pageWidth / 2, y, { align: 'center' });
-  y += 6;
-  doc.text('3. Siga o link para pegar sua senha.', pageWidth / 2, y, { align: 'center' });
-  y += 10;
-  doc.setFontSize(10);
-  doc.text(currentClientUrl, pageWidth / 2, y, { align: 'center' });
+    y += 80;
+    doc.setFontSize(12);
+    doc.text('1. Abra a câmera do seu celular.', pageWidth / 2, y, { align: 'center' });
+    y += 6;
+    doc.text('2. Siga o link para pegar sua senha.', pageWidth / 2, y, { align: 'center' });
+    y += 10;
+    doc.setFontSize(10);
+    doc.text(currentClientUrl, pageWidth / 2, y, { align: 'center' });
   const empresaSlug = sanitizeFileName(cfg.empresa);
   doc.save(`${empresaSlug}-instrucoes-fila.pdf`);
 }


### PR DESCRIPTION
## Summary
- Display QR code in header beside unit name and align it to the right
- Add PDF export button adjacent to QR code
- Simplify onboarding PDF instructions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8ec8c3a888329975758c6b1d63e9f