### PR TITLE
Align QR code with company name in attendant header

### DIFF
--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -427,7 +427,8 @@ body {
 /* Header principal */
 .header {
   display: flex;
-  align-items: center;
+  justify-content: space-between;
+  align-items: flex-start;
   padding: 0.75rem 1rem;
   background-color: #005a9c;
   color: #fff;
@@ -748,6 +749,14 @@ body {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+
+.header-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
 }
 
 #btn-qr-pdf {

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -86,10 +86,12 @@
       <span id="header-schedule" class="header-schedule"></span>
     </div>
   </div>
-  <button id="admin-toggle" class="btn btn-secondary" aria-label="Administração">⚙️</button>
-  <div class="qrcode-wrapper">
-    <div id="qrcode"></div>
-    <button id="btn-qr-pdf" class="btn btn-secondary" hidden>PDF</button>
+  <div class="header-actions">
+    <div class="qrcode-wrapper">
+      <div id="qrcode"></div>
+      <button id="btn-qr-pdf" class="btn btn-secondary" hidden>PDF</button>
+    </div>
+    <button id="admin-toggle" class="btn btn-secondary" aria-label="Administração">⚙️</button>
   </div>
   <nav id="admin-panel" class="admin-panel" hidden>
     <h3>Administração</h3>


### PR DESCRIPTION
## Summary
- Reposition QR image and PDF button to share the header line with the company name
- Add header-actions container to place QR code above the configuration button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8f355c69483298fdd6fe7a72b5580