### PR TITLE
Manter relatório e reset ativos com tickets finalizados

### DIFF
--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -634,26 +634,28 @@ function startBouncingCompanyName(text) {
       const waitingNormal = Math.max(0, waiting - waitingPriority);
       const hasPriorityTicket = waitingPriority > 0 || prioritySet.has(currentCallNum);
       const hasNormalTicket = waitingNormal > 0 || (currentCallNum > 0 && !prioritySet.has(currentCallNum));
-      const hasAnyTicket = hasPriorityTicket || hasNormalTicket;
+      const hasWaitingTicket = hasPriorityTicket || hasNormalTicket;
+      const hasFinishedTicket = cancelledNums.length > 0 || missedNums.length > 0 || attendedNums.length > 0;
+      const hasAnyTicket = hasWaitingTicket || hasFinishedTicket;
       if (btnNextPref) {
         btnNextPref.disabled = !hasPriorityTicket;
         btnNextPref.title = hasPriorityTicket
           ? ''
-          : (hasAnyTicket ? 'Sem tickets preferenciais na fila' : 'Sem tickets na fila');
+          : (hasWaitingTicket ? 'Sem tickets preferenciais na fila' : 'Sem tickets na fila');
       }
       if (btnNext) {
         btnNext.disabled = !hasNormalTicket;
         btnNext.title = hasNormalTicket
           ? ''
-          : (hasAnyTicket ? 'Sem tickets normais na fila' : 'Sem tickets na fila');
+          : (hasWaitingTicket ? 'Sem tickets normais na fila' : 'Sem tickets na fila');
       }
       if (btnRepeat) {
-        btnRepeat.disabled = !hasAnyTicket;
-        btnRepeat.title = hasAnyTicket ? '' : 'Sem tickets na fila';
+        btnRepeat.disabled = !hasWaitingTicket;
+        btnRepeat.title = hasWaitingTicket ? '' : 'Sem tickets na fila';
       }
       if (btnDone) {
-        btnDone.disabled = !hasAnyTicket;
-        btnDone.title = hasAnyTicket ? '' : 'Sem tickets na fila';
+        btnDone.disabled = !hasWaitingTicket;
+        btnDone.title = hasWaitingTicket ? '' : 'Sem tickets na fila';
       }
       if (btnReport) {
         btnReport.disabled = !hasAnyTicket;


### PR DESCRIPTION
## Summary
- Garante que botões de relatório e reset permaneçam habilitados quando houver tickets cancelados, perdidos ou atendidos
- Ajusta lógica de habilitação de botões para distinguir entre tickets em espera e finalizados

## Testing
- `npm test` *(erro: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b969084050832984c9b148c3b3d486