### PR TITLE
Add cancel button to clean queue items

### DIFF
--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -412,6 +412,18 @@ body {
   padding: 0.5rem 0;
   border-bottom: 1px solid #eee;
 }
+.list li .cancel-btn {
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0 0.25rem;
+  font-size: 1rem;
+  line-height: 1;
+}
+.list li .cancel-btn:hover {
+  color: var(--danger);
+}
 .list li.missed {
   color: var(--warning);
 }

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -542,6 +542,21 @@ function startBouncingCompanyName(text) {
     currentIdEl.textContent   = attendantId || '';
   }
 
+  async function cancelTicket(n) {
+    if (!window.confirm(`Cancelar o ticket ${n}?`)) return;
+    const t = token;
+    try {
+      await fetch(`/.netlify/functions/cancelar?t=${t}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ticket: n, reason: 'desk' })
+      });
+      await refreshAll(t);
+    } catch (e) {
+      console.error('Erro ao cancelar ticket:', e);
+    }
+  }
+
   function updateQueueList() {
     if (!queueListEl) return;
     queueListEl.innerHTML = '';
@@ -563,7 +578,19 @@ function startBouncingCompanyName(text) {
       let text = nm ? `${n} - ${nm}` : String(n);
       text += prioritySet.has(n) ? ' - Preferencial' : ' - Normal';
       if (offHoursSet.has(n)) text += ' - Fora do horário';
-      li.textContent = text;
+
+      const span = document.createElement('span');
+      span.textContent = text;
+      li.appendChild(span);
+
+      const btn = document.createElement('button');
+      btn.className = 'cancel-btn';
+      btn.textContent = '×';
+      btn.title = 'Cancelar ticket';
+      btn.setAttribute('aria-label', `Cancelar ticket ${n}`);
+      btn.onclick = () => cancelTicket(n);
+      li.appendChild(btn);
+
       queueListEl.appendChild(li);
     });
   }


### PR DESCRIPTION
## Summary
- Add discrete cancel button for each pending ticket in the attendant monitor
- Style cancel button with muted color and danger hover state
- Prompt attendants for confirmation before removing a ticket

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b97b7bf894832994cbc0287bd0e605