### PR TITLE
Align normal ticket buttons with chip color

### DIFF
--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -11,6 +11,7 @@
   --muted:      #666;
   --radius:     6px;
   --font:       'Helvetica Neue', Arial, sans-serif;
+  --normal-bg:  #e0e0e0;
 }
 
 * {
@@ -252,7 +253,7 @@ body {
 .queue-summary .chip {
   padding: 0.25rem 0.5rem;
   border-radius: var(--radius);
-  background: #e0e0e0;
+  background: var(--normal-bg);
 }
 .queue-summary .chip.pref {
   background: var(--warning);
@@ -295,6 +296,10 @@ body {
 .btn-preferential {
   background: var(--warning);
   color: #333;
+}
+.btn-normal {
+  background: var(--normal-bg);
+  color: var(--text);
 }
 .btn-ghost {
   background: #fff;

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -148,7 +148,7 @@
         </div>
       </div>
       <div class="btn-grid">
-        <button id="btn-next" class="btn btn-primary" aria-label="Chamar próximo ticket" title="Chamar próximo ticket">
+        <button id="btn-next" class="btn btn-normal" aria-label="Chamar próximo ticket" title="Chamar próximo ticket">
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
           <span>Próximo</span>
         </button>
@@ -164,7 +164,7 @@
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 13l4 4L19 7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
           <span>Atendido</span>
         </button>
-        <button id="btn-ticket" class="btn btn-ghost" aria-label="Gerar ticket" title="Gerar ticket">
+        <button id="btn-ticket" class="btn btn-normal" aria-label="Gerar ticket" title="Gerar ticket">
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 7h18v10H3z" stroke="currentColor" stroke-width="2" fill="none"/><path d="M8 7v10M16 7v10M3 12h18" stroke="currentColor" stroke-width="2" fill="none"/></svg>
           <span>Ticket</span>
         </button>


### PR DESCRIPTION
## Summary
- Use same neutral color for "Próximo" and "Ticket" buttons as the "Normais" chip
- Introduce CSS variable for normal ticket color

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b988a1d7a08329932777b661e28c22