### PR TITLE
style: darken Normal button gray tone

### DIFF
--- a/public/client/css/client.css
+++ b/public/client/css/client.css
@@ -244,6 +244,17 @@ button {
   color: #fff;
 }
 
+#btn-normal {
+  border-color: #b0b0b0;
+  background: #b0b0b0;
+  color: #fff;
+}
+
+#btn-normal:hover {
+  background: #999;
+  border-color: #999;
+}
+
 .ticket-selection .hint {
   font-size: 0.875rem;
   color: var(--muted);

--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -11,7 +11,7 @@
   --muted:      #666;
   --radius:     6px;
   --font:       'Helvetica Neue', Arial, sans-serif;
-  --normal-bg:  #e0e0e0;
+  --normal-bg:  #b0b0b0;
 }
 
 * {


### PR DESCRIPTION
## Summary
- Intensified Normal button background via `--normal-bg` variable
- Styled client Normal ticket button with darker gray and hover state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b98c03e14c83299d2c1b583a6ba24c