### PR TITLE
Encerrar conexão do cliente ao cancelar ticket

### DIFF
--- a/public/client/js/client.js
+++ b/public/client/js/client.js
@@ -305,6 +305,11 @@ async function checkStatus() {
     return;
   }
 
+  if (cancelledNumbers.includes(ticketNumber)) {
+    handleExit("Seu atendimento foi cancelado.");
+    return;
+  }
+
   if (missedNumbers.includes(ticketNumber)) {
     handleExit("Você perdeu a vez.");
     return;


### PR DESCRIPTION
## Resumo
- Finaliza a sessão do cliente quando o ticket é cancelado pelo atendente

## Testes
- `npm test` *(falhou: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b99cd83ee48329abdc224bc85eca20