### PR TITLE
Fix repeat button availability and icon

### DIFF
--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -156,8 +156,13 @@
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/><path d="M5 3l2 4 4 .5-3 3 1 4-4-2-4 2 1-4-3-3 4-.5z" fill="currentColor"/></svg>
           <span>Próximo Preferencial</span>
         </button>
-        <button id="btn-repeat" class="btn btn-ghost" aria-label="Repetir chamada" title="Repetir chamada">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 4v6h6M20 20v-6h-6" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/><path d="M20 9A8 8 0 1 0 4 15" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <button id="btn-repeat" class="btn btn-ghost" aria-label="Repetir chamada" title="Repetir chamada" disabled>
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="m17 2 4 4-4 4" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M3 11v-1a4 4 0 0 1 4-4h14" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="m7 22-4-4 4-4" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M21 13v1a4 4 0 0 1-4 4H3" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
           <span>Repetir</span>
         </button>
         <button id="btn-done" class="btn btn-success" aria-label="Marcar como atendido" title="Marcar como atendido">

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -662,6 +662,7 @@ function startBouncingCompanyName(text) {
       const hasPriorityTicket = waitingPriority > 0 || prioritySet.has(currentCallNum);
       const hasNormalTicket = waitingNormal > 0 || (currentCallNum > 0 && !prioritySet.has(currentCallNum));
       const hasWaitingTicket = hasPriorityTicket || hasNormalTicket;
+      const hasCallingTicket = currentCallNum > 0;
       const hasFinishedTicket = cancelledNums.length > 0 || missedNums.length > 0 || attendedNums.length > 0;
       const hasAnyTicket = hasWaitingTicket || hasFinishedTicket;
       if (btnNextPref) {
@@ -677,8 +678,8 @@ function startBouncingCompanyName(text) {
           : (hasWaitingTicket ? 'Sem tickets normais na fila' : 'Sem tickets na fila');
       }
       if (btnRepeat) {
-        btnRepeat.disabled = !hasWaitingTicket;
-        btnRepeat.title = hasWaitingTicket ? '' : 'Sem tickets na fila';
+        btnRepeat.disabled = !hasCallingTicket;
+        btnRepeat.title = hasCallingTicket ? '' : 'Sem ticket em chamada';
       }
       if (btnDone) {
         btnDone.disabled = !hasWaitingTicket;
@@ -1266,6 +1267,7 @@ function startBouncingCompanyName(text) {
       refreshAll(t);
     };
     btnRepeat.onclick = async () => {
+      if (!currentCallNum) return;
       const id = attendantInput.value.trim();
       let url = `/.netlify/functions/chamar?t=${t}&num=${currentCallNum}`;
       if (id) url += `&id=${encodeURIComponent(id)}`;


### PR DESCRIPTION
## Summary
- Replace cropped Repeat icon with full SVG
- Enable Repeat only when a ticket is currently being called
- Guard repeat action when no active call exists

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9b4cf28a88329b84e76aa798432cb