### PR TITLE
Enable Atendido button only when a ticket is active

### DIFF
--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -165,7 +165,7 @@
           </svg>
           <span>Repetir</span>
         </button>
-        <button id="btn-done" class="btn btn-success" aria-label="Marcar como atendido" title="Marcar como atendido">
+        <button id="btn-done" class="btn btn-success" aria-label="Marcar como atendido" title="Marcar como atendido" disabled>
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 13l4 4L19 7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
           <span>Atendido</span>
         </button>

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -682,8 +682,8 @@ function startBouncingCompanyName(text) {
         btnRepeat.title = hasCallingTicket ? '' : 'Sem ticket em chamada';
       }
       if (btnDone) {
-        btnDone.disabled = !hasWaitingTicket;
-        btnDone.title = hasWaitingTicket ? '' : 'Sem tickets na fila';
+        btnDone.disabled = !hasCallingTicket;
+        btnDone.title = hasCallingTicket ? '' : 'Sem ticket em chamada';
       }
       if (btnReport) {
         btnReport.disabled = !hasAnyTicket;


### PR DESCRIPTION
## Summary
- Disable Atendido button by default
- Restrict Atendido button availability to when a ticket is being called

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9b7ef0e888329b78ededa73048cfb