### PR TITLE
feat: add attendant panel keyboard shortcuts

### DIFF
--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -914,4 +914,6 @@ body {
   }
 }
 
+.kbd-flash{ outline:2px solid #4f46e5; transition: outline-color .15s; }
+
 

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -142,26 +142,26 @@
         </div>
       </div>
       <div class="actions">
-        <button id="btn-next" class="btn btn-primary" aria-label="Chamar próximo ticket" title="Chamar próximo ticket">
+        <button id="btn-next" class="btn btn-primary" aria-label="Chamar próximo ticket" title="Próximo (N)" data-action="next">
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
-          <span>Próximo</span>
+          <span>Próximo (N)</span>
         </button>
-        <button id="btn-next-pref" class="btn btn-pref" aria-label="Chamar próximo ticket preferencial" title="Chamar próximo ticket preferencial">
+        <button id="btn-next-pref" class="btn btn-pref" aria-label="Chamar próximo ticket preferencial" title="Preferencial (P)" data-action="priority">
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/><path d="M5 3l2 4 4 .5-3 3 1 4-4-2-4 2 1-4-3-3 4-.5z" fill="currentColor"/></svg>
-          <span>Próximo Preferencial</span>
+          <span>Preferencial (P)</span>
         </button>
-        <button id="btn-repeat" class="btn btn-ghost" aria-label="Repetir chamada" title="Repetir chamada" disabled>
+        <button id="btn-repeat" class="btn btn-ghost" aria-label="Repetir chamada" title="Repetir (R)" data-action="repeat" disabled>
           <svg viewBox="0 0 24 24" aria-hidden="true">
             <path d="m17 2 4 4-4 4" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
             <path d="M3 11v-1a4 4 0 0 1 4-4h14" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
             <path d="m7 22-4-4 4-4" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
             <path d="M21 13v1a4 4 0 0 1-4 4H3" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
           </svg>
-          <span>Repetir</span>
+          <span>Repetir (R)</span>
         </button>
-        <button id="btn-done" class="btn btn-success" aria-label="Marcar como atendido" title="Marcar como atendido" disabled>
+        <button id="btn-done" class="btn btn-success" aria-label="Marcar como atendido" title="Atendido (A)" data-action="attended" disabled>
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 13l4 4L19 7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
-          <span>Atendido</span>
+          <span>Atendido (A)</span>
         </button>
         <button id="btn-ticket" class="btn btn-ghost" aria-label="Gerar ticket" title="Gerar ticket">
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 7h18v10H3z" stroke="currentColor" stroke-width="2" fill="none"/><path d="M8 7v10M16 7v10M3 12h18" stroke="currentColor" stroke-width="2" fill="none"/></svg>

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -1557,3 +1557,35 @@ function startBouncingCompanyName(text) {
       setTimeout(() => ripple.remove(), 600);
     });
   });
+
+const $btnNext     = document.querySelector('[data-action="next"]');
+const $btnPriority = document.querySelector('[data-action="priority"]');
+const $btnAttended = document.querySelector('[data-action="attended"]');
+const $btnRepeat   = document.querySelector('[data-action="repeat"]');
+
+function isTyping(el){
+  if(!el) return false;
+  const tag = el.tagName?.toLowerCase();
+  return el.isContentEditable || tag === 'input' || tag === 'textarea' || tag === 'select';
+}
+
+function flash(btn){
+  if(!btn) return;
+  btn.classList.add('kbd-flash');
+  setTimeout(()=>btn.classList.remove('kbd-flash'),150);
+}
+
+function clickIfEnabled(btn){ if(btn && !btn.disabled) btn.click(); }
+
+document.addEventListener('keydown', (ev)=>{
+  if(ev.ctrlKey || ev.metaKey || ev.altKey) return;
+  if(isTyping(document.activeElement)) return;
+
+  const k = ev.key?.toLowerCase();
+  if(['n','p','a','r'].includes(k)) ev.preventDefault();
+
+  if(k === 'n'){ clickIfEnabled($btnNext);     flash($btnNext); }
+  if(k === 'p'){ clickIfEnabled($btnPriority); flash($btnPriority); }
+  if(k === 'a'){ clickIfEnabled($btnAttended); flash($btnAttended); }
+  if(k === 'r'){ clickIfEnabled($btnRepeat);   flash($btnRepeat); }
+});


### PR DESCRIPTION
## Summary
- add `data-action` attributes and shortcut hints for next, priority, attended, and repeat buttons
- enable N/P/A/R keyboard shortcuts with visual flash feedback
- style shortcut flash outline

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc2286a63483299f18ec486804b154