### PR TITLE
feat: add ticket creation shortcuts

### DIFF
--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -163,13 +163,13 @@
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 13l4 4L19 7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
           <span>Atendido (A)</span>
         </button>
-        <button id="btn-ticket" class="btn btn-ghost" aria-label="Gerar ticket" title="Gerar ticket">
+        <button id="btn-ticket" class="btn btn-ghost" aria-label="Gerar ticket" title="Ticket Normal (T)" data-action="ticket-normal">
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 7h18v10H3z" stroke="currentColor" stroke-width="2" fill="none"/><path d="M8 7v10M16 7v10M3 12h18" stroke="currentColor" stroke-width="2" fill="none"/></svg>
-          <span>Ticket</span>
+          <span>Ticket Normal (T)</span>
         </button>
-        <button id="btn-ticket-pref" class="btn btn-pref" aria-label="Gerar ticket preferencial" title="Gerar ticket preferencial">
+        <button id="btn-ticket-pref" class="btn btn-pref" aria-label="Gerar ticket preferencial" title="Ticket Preferencial (Shift+T)" data-action="ticket-preferential">
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 7h18v10H3z" stroke="currentColor" stroke-width="2" fill="none"/><path d="M8 7v10M16 7v10M3 12h18" stroke="currentColor" stroke-width="2" fill="none"/><path d="M5 2l1.5 3 3 .4-2.2 2.2.5 3-2.8-1.5-2.8 1.5.5-3L0 5.4l3-.4z" fill="currentColor"/></svg>
-          <span>Ticket Preferencial</span>
+          <span>Ticket Preferencial (Shift+T)</span>
         </button>
       </div>
       <div class="footer-buttons">

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -1562,6 +1562,8 @@ const $btnNext     = document.querySelector('[data-action="next"]');
 const $btnPriority = document.querySelector('[data-action="priority"]');
 const $btnAttended = document.querySelector('[data-action="attended"]');
 const $btnRepeat   = document.querySelector('[data-action="repeat"]');
+const $btnTicketNormal = document.querySelector('[data-action="ticket-normal"]');
+const $btnTicketPref   = document.querySelector('[data-action="ticket-preferential"]');
 
 function isTyping(el){
   if(!el) return false;
@@ -1582,10 +1584,14 @@ document.addEventListener('keydown', (ev)=>{
   if(isTyping(document.activeElement)) return;
 
   const k = ev.key?.toLowerCase();
-  if(['n','p','a','r'].includes(k)) ev.preventDefault();
+  if(['n','p','a','r','t'].includes(k)) ev.preventDefault();
 
   if(k === 'n'){ clickIfEnabled($btnNext);     flash($btnNext); }
   if(k === 'p'){ clickIfEnabled($btnPriority); flash($btnPriority); }
   if(k === 'a'){ clickIfEnabled($btnAttended); flash($btnAttended); }
   if(k === 'r'){ clickIfEnabled($btnRepeat);   flash($btnRepeat); }
+  if(k === 't'){
+    if(ev.shiftKey){ clickIfEnabled($btnTicketPref); flash($btnTicketPref); }
+    else{            clickIfEnabled($btnTicketNormal); flash($btnTicketNormal); }
+  }
 });


### PR DESCRIPTION
## Summary
- enable T and Shift+T keyboard shortcuts to trigger ticket creation buttons
- show shortcut hints on ticket buttons
- support button highlight when invoked via keyboard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bc272652dc8329990856e6ad5ec9e9