### PR TITLE
feat: import client list into queue

### DIFF
--- a/functions/enqueueBatch.js
+++ b/functions/enqueueBatch.js
@@ -1,0 +1,72 @@
+import { Redis } from "@upstash/redis";
+import errorHandler from "./utils/errorHandler.js";
+
+const LOG_TTL = 60 * 60 * 24 * 30; // 30 days
+
+export async function handler(event) {
+  try {
+    const url = new URL(event.rawUrl);
+    const tenantId = url.searchParams.get("t");
+    if (!tenantId) {
+      return { statusCode: 400, body: "Missing tenantId" };
+    }
+
+    let body = {};
+    try {
+      body = JSON.parse(event.body || "{}");
+    } catch {}
+
+    const normal = Array.isArray(body.normal) ? body.normal : [];
+    const preferential = Array.isArray(body.preferential || body.priority) ? (body.preferential || body.priority) : [];
+    if (normal.length === 0 && preferential.length === 0) {
+      return { statusCode: 400, body: "Empty list" };
+    }
+
+    const redis = Redis.fromEnv();
+    const [pwHash, monitor] = await redis.mget(
+      `tenant:${tenantId}:pwHash`,
+      `monitor:${tenantId}`
+    );
+    if (!pwHash && !monitor) {
+      return { statusCode: 404, body: "Invalid link" };
+    }
+
+    const prefix = `tenant:${tenantId}:`;
+    let total = 0;
+    const process = async (name, isPriority) => {
+      const ticketNumber = await redis.incr(prefix + "ticketCounter");
+      const ts = Date.now();
+      const data = {
+        [prefix + `ticketTime:${ticketNumber}`]: ts,
+      };
+      await redis.mset(data);
+      if (name) {
+        await redis.hset(prefix + "ticketNames", { [ticketNumber]: name });
+      }
+      if (isPriority) {
+        await redis.rpush(prefix + "priorityQueue", ticketNumber);
+        await redis.sadd(prefix + "prioritySet", String(ticketNumber));
+        await redis.sadd(prefix + "priorityHistory", String(ticketNumber));
+      }
+      await redis.lpush(prefix + "log:entered", JSON.stringify({ ticket: ticketNumber, ts, name }));
+      await redis.ltrim(prefix + "log:entered", 0, 999);
+      await redis.expire(prefix + "log:entered", LOG_TTL);
+      total++;
+    };
+
+    for (const name of preferential) {
+      await process(name, true);
+    }
+    for (const name of normal) {
+      await process(name, false);
+    }
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ ok: true, imported: total, preferential: preferential.length, normal: normal.length }),
+    };
+  } catch (error) {
+    return errorHandler(error);
+  }
+}
+

--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -708,6 +708,63 @@ body {
   font-size: 0.875rem;
 }
 
+/* Modal de importação de clientes */
+#import-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+#import-modal[hidden] {
+  display: none !important;
+}
+#import-modal .modal-content {
+  background: #fff;
+  padding: 1rem;
+  border-radius: var(--radius);
+  width: 90%;
+  max-width: 500px;
+  max-height: 90%;
+  overflow-y: auto;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.3);
+}
+#import-modal textarea {
+  width: 100%;
+  min-height: 150px;
+  margin-top: 0.5rem;
+}
+#import-modal table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.5rem;
+}
+#import-modal th,
+#import-modal td {
+  border: 1px solid #ccc;
+  padding: 0.25rem 0.5rem;
+  text-align: left;
+}
+#import-modal th {
+  background: #f0f0f0;
+}
+#import-modal .import-actions {
+  margin-top: 1rem;
+  text-align: right;
+}
+#import-modal .note {
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
+}
+#import-modal .import-counts {
+  margin-top: 0.5rem;
+}
+#import-modal .pref-badge {
+  color: var(--danger);
+}
+
 /* Modal de edição de horário */
 #schedule-modal {
   position: fixed;

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -11,6 +11,8 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
   <!-- jsPDF para exportação em PDF -->
   <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+  <!-- Biblioteca para leitura de XLSX -->
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-E0N82XM9NM"></script>
   <script>
@@ -109,6 +111,11 @@
       <button id="btn-view-monitor" class="btn btn-secondary">Espelhar Monitor</button>
       <button id="btn-clone" class="btn btn-secondary">Clonar Atendente</button>
       <button id="btn-change-password" class="btn btn-secondary">Trocar Senha</button>
+    </div>
+
+    <div class="admin-section" id="queue-config-section">
+      <h4>Configuração da Fila</h4>
+      <button id="btn-import-clients" class="btn btn-secondary">Importar lista de clientes</button>
     </div>
 
     <div class="admin-section danger">
@@ -298,6 +305,33 @@
       </div>
       <button id="password-save">Salvar</button>
       <div id="password-error" class="error"></div>
+    </div>
+  </div>
+
+  <!-- Modal de Importação de Clientes -->
+  <div id="import-modal" hidden>
+    <div class="modal-content">
+      <h2>Importar lista de clientes</h2>
+      <div id="import-step-source">
+        <input type="file" id="import-file" accept=".txt,.csv,.xlsx" />
+        <textarea id="import-text" placeholder="Cole os nomes aqui, um por linha"></textarea>
+        <button id="import-load" class="btn btn-secondary">Carregar</button>
+        <div id="import-src-error" class="error"></div>
+      </div>
+      <div id="import-step-preview" hidden>
+        <p class="note" id="import-note">A lista será adicionada ao FINAL das filas atuais (Normais/Preferenciais), preservando a ordem de quem já possui ticket.</p>
+        <div id="import-dup-box" class="error" hidden>
+          Há nomes idênticos (ignorando *). Para evitar confusão no Monitor, edite sua lista e acrescente um diferencial (sobrenome, apelido ou código).
+          <table id="import-dup-table"></table>
+        </div>
+        <table id="import-preview-table" title="Marque preferenciais com * no final do nome. Nomes devem ser únicos."></table>
+        <div class="import-counts">Total <span id="import-count-total">0</span> | Preferenciais <span id="import-count-pref">0</span> | Normais <span id="import-count-normal">0</span></div>
+        <div class="import-actions">
+          <button id="import-confirm" class="btn btn-success" disabled>Confirmar importação</button>
+          <button id="import-clear" class="btn btn-secondary">Limpar lista</button>
+          <button id="import-cancel" class="btn btn-secondary">Cancelar</button>
+        </div>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- allow admins to import client lists with preferential flag and duplicate validation
- append imported names at end of queues via new serverless batch endpoint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc3574f7dc83299cad3fb15819331b