### PR TITLE
Preserve imported queue order

### DIFF
--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -319,7 +319,7 @@
         <div id="import-src-error" class="error"></div>
       </div>
       <div id="import-step-preview" hidden>
-        <p class="note" id="import-note">A lista será adicionada ao FINAL das filas atuais (Normais/Preferenciais), preservando a ordem de quem já possui ticket.</p>
+        <p class="note" id="import-note">A lista será adicionada ao FINAL da Fila Virtual, mantendo a ordem do arquivo.</p>
         <div id="import-dup-box" class="error" hidden>
           Há nomes idênticos (ignorando *). Para evitar confusão no Monitor, edite sua lista e acrescente um diferencial (sobrenome, apelido ou código).
           <table id="import-dup-table"></table>

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -500,16 +500,17 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   importConfirm?.addEventListener('click', async () => {
     const t = token;
-    const normals = importItems.filter((i) => !i.priority).map((i) => i.name);
-    const prefs = importItems.filter((i) => i.priority).map((i) => i.name);
+    const items = importItems.map((i) => ({ name: i.name, preferential: i.priority }));
     try {
       const res = await fetch(`/.netlify/functions/enqueueBatch?t=${t}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ normal: normals, preferential: prefs })
+        body: JSON.stringify({ items })
       });
       if (!res.ok) throw new Error();
-      alert(`Importados: ${importItems.length} (${prefs.length} preferenciais, ${normals.length} normais)`);
+      const prefCount = items.filter((i) => i.preferential).length;
+      const normCount = items.length - prefCount;
+      alert(`Importados: ${items.length} (${prefCount} preferenciais, ${normCount} normais)`);
       importModal.hidden = true;
       resetImport();
       refreshAll(t);


### PR DESCRIPTION
## Summary
- Keep batch import order by sending single ordered item list
- Append items to queue sequentially and track preferential counts
- Show canceled, missed and attended status panels on the attendant screen
- Update import confirmation note to clarify list appended at end

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc3b1dbcdc8329aa31ab030e533e10