### PR TITLE
Add progress bar to client import

### DIFF
--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -766,6 +766,20 @@ body {
 #import-modal .import-counts {
   margin-top: 0.5rem;
 }
+#import-modal .import-progress {
+  margin-top: 0.5rem;
+  width: 100%;
+  height: 10px;
+  background: var(--gray-200);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+#import-modal .import-progress-bar {
+  height: 100%;
+  width: 0;
+  background: var(--primary);
+  transition: width 0.2s;
+}
 #import-modal .pref-badge {
   color: var(--danger);
 }

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -327,6 +327,9 @@
         </div>
         <table id="import-preview-table" title="Marque preferenciais com * no final do nome. Nomes devem ser únicos."></table>
         <div class="import-counts">Total <span id="import-count-total">0</span> | Preferenciais <span id="import-count-pref">0</span> | Normais <span id="import-count-normal">0</span></div>
+        <div id="import-progress" class="import-progress" hidden>
+          <div id="import-progress-bar" class="import-progress-bar"></div>
+        </div>
         <div class="import-actions">
           <button id="import-confirm" class="btn btn-success" disabled>Confirmar importação</button>
           <button id="import-clear" class="btn btn-secondary">Limpar lista</button>

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -239,6 +239,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const importDupBox   = document.getElementById('import-dup-box');
   const importDupTable = document.getElementById('import-dup-table');
   const importSrcError = document.getElementById('import-src-error');
+  const importProgress = document.getElementById('import-progress');
+  const importProgressBar = document.getElementById('import-progress-bar');
   const togglePwCurrent= document.getElementById('toggle-password-current');
   const clonesPanel = document.querySelector('.clones-panel');
   if (clonesPanel) clonesPanel.hidden = true;
@@ -374,6 +376,11 @@ document.addEventListener('DOMContentLoaded', () => {
     importConfirm.disabled = true;
     importDupBox.hidden = true;
     importDupTable.innerHTML = '';
+    importProgress.hidden = true;
+    importProgressBar.style.width = '0%';
+    importClear.disabled = false;
+    importCancel.disabled = false;
+    importClose.hidden = false;
   }
   function normalizeName(str) {
     return str
@@ -509,22 +516,46 @@ document.addEventListener('DOMContentLoaded', () => {
   importConfirm?.addEventListener('click', async () => {
     const t = token;
     const items = importItems.map((i) => ({ name: i.name, preferential: i.priority }));
+    const total = items.length;
+    const batchSize = 100;
+    let processed = 0;
+    let prefCount = 0;
+    let normCount = 0;
+    importProgress.hidden = false;
+    importProgressBar.style.width = '0%';
+    importConfirm.disabled = true;
+    importClear.disabled = true;
+    importCancel.disabled = true;
+    importClose.hidden = true;
     try {
-      const res = await fetch(`/.netlify/functions/enqueueBatch?t=${t}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ items })
-      });
-      if (!res.ok) throw new Error();
-      const prefCount = items.filter((i) => i.preferential).length;
-      const normCount = items.length - prefCount;
-      alert(`Importados: ${items.length} (${prefCount} preferenciais, ${normCount} normais)`);
+      while (processed < total) {
+        const batch = items.slice(processed, processed + batchSize);
+        const res = await fetch(`/.netlify/functions/enqueueBatch?t=${t}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ items: batch })
+        });
+        if (!res.ok) throw new Error();
+        const data = await res.json();
+        prefCount += data.preferential || 0;
+        normCount += data.normal || 0;
+        processed += batch.length;
+        importProgressBar.style.width = `${(processed / total) * 100}%`;
+      }
+      alert(`Importados: ${total} (${prefCount} preferenciais, ${normCount} normais)`);
       importModal.hidden = true;
       resetImport();
       refreshAll(t);
     } catch (e) {
       alert('Erro ao importar lista');
       console.error(e);
+    } finally {
+      importProgress.hidden = true;
+      importProgressBar.style.width = '0%';
+      importConfirm.disabled = false;
+      importClear.disabled = false;
+      importCancel.disabled = false;
+      importClose.hidden = false;
     }
   });
 


### PR DESCRIPTION
## Summary
- add progress bar UI to client import modal
- send client imports in batches with visual progress feedback

## Testing
- `node --check public/monitor-attendant/js/monitor-attendant.js`
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc85336c648329b929d6636aaac90f