### PR TITLE
Add progress bar to client import

### DIFF
--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -766,6 +766,20 @@ body {
 #import-modal .import-counts {
   margin-top: 0.5rem;
 }
+#import-modal .import-progress {
+  margin-top: 0.5rem;
+  width: 100%;
+  height: 10px;
+  background: var(--gray-200);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+#import-modal .import-progress-bar {
+  height: 100%;
+  width: 0;
+  background: var(--primary);
+  transition: width 0.2s;
+}
 #import-modal .pref-badge {
   color: var(--danger);
 }

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -327,6 +327,9 @@
         </div>
         <table id="import-preview-table" title="Marque preferenciais com * no final do nome. Nomes devem ser únicos."></table>
         <div class="import-counts">Total <span id="import-count-total">0</span> | Preferenciais <span id="import-count-pref">0</span> | Normais <span id="import-count-normal">0</span></div>
+        <div id="import-progress" class="import-progress" hidden>
+          <div id="import-progress-bar" class="import-progress-bar"></div>
+        </div>
         <div class="import-actions">
           <button id="import-confirm" class="btn btn-success" disabled>Confirmar importação</button>
           <button id="import-clear" class="btn btn-secondary">Limpar lista</button>


### PR DESCRIPTION
## Summary
- add progress bar UI to client import modal
- send client imports in batches with visual progress feedback
- ensure progress bar renders before processing and improve error handling

## Testing
- `node --check public/monitor-attendant/js/monitor-attendant.js`
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc85336c648329b929d6636aaac90f