### PR TITLE
Use browser language as speech fallback

### DIFF
--- a/public/client/js/client.js
+++ b/public/client/js/client.js
@@ -43,6 +43,7 @@ const defaultSchedule = {
     { start: '13:00', end: '18:00' }
   ]
 };
+const defaultLang = navigator.language || 'pt-BR';
 
 async function safeFetch(url, options) {
   const res = await fetch(url, options);
@@ -402,7 +403,9 @@ function alertUser(name) {
   sendNotification(name);
   if ('speechSynthesis' in window) {
     const utter = new SpeechSynthesisUtterance(`É a sua vez: ${ticketNumber} ${name || ''}`);
-    utter.lang = 'pt-BR';
+    if (!window.cfg || window.cfg.speakOriginalLang === false) {
+      utter.lang = defaultLang;
+    }
     speechSynthesis.speak(utter);
   }
   alertInterval = setInterval(doAlert, 5000);

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -107,6 +107,11 @@
           <input type="checkbox" id="pref-desk-toggle" checked>
           <label for="pref-desk-toggle">Guichê preferencial</label>
         </div>
+        <div class="pref-toggle">
+          <input type="checkbox" id="speak-original-toggle" checked>
+          <label for="speak-original-toggle">Pronunciar nome no idioma original <span id="browser-lang"></span></label>
+        </div>
+        <small class="note">Se desativado, o idioma do navegador atual será usado.</small>
       <button id="btn-edit-schedule" class="btn btn-secondary">Editar Horário</button>
       <button id="btn-view-monitor" class="btn btn-secondary">Espelhar Monitor</button>
       <button id="btn-clone" class="btn btn-secondary">Clonar Atendente</button>

--- a/public/monitor-attendant/js/monitor-attendant.js
+++ b/public/monitor-attendant/js/monitor-attendant.js
@@ -35,6 +35,10 @@ document.addEventListener('DOMContentLoaded', () => {
     cfg.preferentialDesk = true;
     localStorage.setItem('monitorConfig', JSON.stringify(cfg));
   }
+  if (cfg && typeof cfg.speakOriginalLang === 'undefined') {
+    cfg.speakOriginalLang = true;
+    localStorage.setItem('monitorConfig', JSON.stringify(cfg));
+  }
   let logoutVersion   = localStorage.getItem('logoutVersion');
   logoutVersion       = logoutVersion !== null ? Number(logoutVersion) : null;
 
@@ -161,6 +165,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const setTicketBtn   = document.getElementById('set-ticket');
   const ticketError    = document.getElementById('ticket-error');
   const prefDeskToggle = document.getElementById('pref-desk-toggle');
+  const speakOriginalToggle = document.getElementById('speak-original-toggle');
+  const browserLangInfo = document.getElementById('browser-lang');
+  if (browserLangInfo) browserLangInfo.textContent = `(${navigator.language || 'pt-BR'})`;
   if (prefDeskToggle) {
     prefDeskToggle.checked = cfg ? cfg.preferentialDesk !== false : true;
     prefDeskToggle.addEventListener('change', async () => {
@@ -173,16 +180,42 @@ document.addEventListener('DOMContentLoaded', () => {
         const res = await fetch(`${location.origin}/.netlify/functions/saveMonitorConfig`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ token, empresa: cfg.empresa, senha: cfg.senha, schedule: cfg.schedule, preferentialDesk })
+          body: JSON.stringify({ token, empresa: cfg.empresa, senha: cfg.senha, schedule: cfg.schedule, preferentialDesk, speakOriginalLang: speakOriginalToggle ? speakOriginalToggle.checked : cfg.speakOriginalLang })
         });
         const data = await res.json();
         if (!res.ok || !data.ok) throw new Error();
         cfg.preferentialDesk = preferentialDesk;
+        cfg.speakOriginalLang = speakOriginalToggle ? speakOriginalToggle.checked : cfg.speakOriginalLang;
         localStorage.setItem('monitorConfig', JSON.stringify(cfg));
       } catch (e) {
         alert('Erro ao salvar configuração.');
         console.error(e);
         prefDeskToggle.checked = !preferentialDesk;
+      }
+    });
+  }
+  if (speakOriginalToggle) {
+    speakOriginalToggle.checked = cfg ? cfg.speakOriginalLang !== false : true;
+    speakOriginalToggle.addEventListener('change', async () => {
+      if (isClone) {
+        speakOriginalToggle.checked = cfg.speakOriginalLang !== false;
+        return;
+      }
+      const speakOriginalLang = speakOriginalToggle.checked;
+      try {
+        const res = await fetch(`${location.origin}/.netlify/functions/saveMonitorConfig`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token, empresa: cfg.empresa, senha: cfg.senha, schedule: cfg.schedule, preferentialDesk: prefDeskToggle ? prefDeskToggle.checked : cfg.preferentialDesk, speakOriginalLang })
+        });
+        const data = await res.json();
+        if (!res.ok || !data.ok) throw new Error();
+        cfg.speakOriginalLang = speakOriginalLang;
+        localStorage.setItem('monitorConfig', JSON.stringify(cfg));
+      } catch (e) {
+        alert('Erro ao salvar configuração.');
+        console.error(e);
+        speakOriginalToggle.checked = !speakOriginalLang;
       }
     });
   }
@@ -303,12 +336,13 @@ document.addEventListener('DOMContentLoaded', () => {
       const res = await fetch(`${location.origin}/.netlify/functions/saveMonitorConfig`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ token, empresa: cfg.empresa, senha: cfg.senha, schedule, preferentialDesk: prefDeskToggle.checked })
+        body: JSON.stringify({ token, empresa: cfg.empresa, senha: cfg.senha, schedule, preferentialDesk: prefDeskToggle.checked, speakOriginalLang: speakOriginalToggle ? speakOriginalToggle.checked : cfg.speakOriginalLang })
       });
       const data = await res.json();
       if (!res.ok || !data.ok) throw new Error();
       cfg.schedule = schedule;
       cfg.preferentialDesk = prefDeskToggle.checked;
+      cfg.speakOriginalLang = speakOriginalToggle ? speakOriginalToggle.checked : cfg.speakOriginalLang;
       localStorage.setItem('monitorConfig', JSON.stringify(cfg));
       scheduleModal.hidden = true;
     } catch (e) {
@@ -1604,6 +1638,7 @@ function startBouncingCompanyName(text) {
         token = urlParams.get('t');
       } else {
         if (prefDeskToggle) prefDeskToggle.checked = cfg.preferentialDesk !== false;
+        if (speakOriginalToggle) speakOriginalToggle.checked = cfg.speakOriginalLang !== false;
         showApp(cfg.empresa, token);
         return;
       }
@@ -1621,10 +1656,11 @@ function startBouncingCompanyName(text) {
           body: JSON.stringify({ token, senha: senhaPrompt })
         });
         if (!res.ok) throw new Error();
-        const { empresa, schedule, preferentialDesk } = await res.json();
-        cfg = { token, empresa, senha: senhaPrompt, schedule, preferentialDesk };
+        const { empresa, schedule, preferentialDesk, speakOriginalLang } = await res.json();
+        cfg = { token, empresa, senha: senhaPrompt, schedule, preferentialDesk, speakOriginalLang };
         localStorage.setItem('monitorConfig', JSON.stringify(cfg));
         if (prefDeskToggle) prefDeskToggle.checked = cfg.preferentialDesk !== false;
+        if (speakOriginalToggle) speakOriginalToggle.checked = cfg.speakOriginalLang !== false;
         history.replaceState(null, '', `/monitor-attendant/?empresa=${encodeURIComponent(empresaParam)}`);
         showApp(empresa, token);
         return;
@@ -1685,9 +1721,10 @@ function startBouncingCompanyName(text) {
           body: JSON.stringify({ token, senha: pw })
         });
         const cfgData = await cfgRes.json();
-        cfg = { token, empresa: cfgData.empresa, senha: pw, schedule: cfgData.schedule, preferentialDesk: cfgData.preferentialDesk };
+        cfg = { token, empresa: cfgData.empresa, senha: pw, schedule: cfgData.schedule, preferentialDesk: cfgData.preferentialDesk, speakOriginalLang: cfgData.speakOriginalLang };
         localStorage.setItem('monitorConfig', JSON.stringify(cfg));
         if (prefDeskToggle) prefDeskToggle.checked = cfg.preferentialDesk !== false;
+        if (speakOriginalToggle) speakOriginalToggle.checked = cfg.speakOriginalLang !== false;
         history.replaceState(null, '', `/monitor-attendant/?empresa=${encodeURIComponent(cfgData.empresa)}`);
         showApp(cfgData.empresa, token);
       } catch (e) {
@@ -1719,9 +1756,10 @@ function startBouncingCompanyName(text) {
           body: JSON.stringify({ token, senha: pw })
         });
         const cfgData = await cfgRes.json();
-        cfg = { token, empresa: cfgData.empresa, senha: pw, schedule: cfgData.schedule, preferentialDesk: cfgData.preferentialDesk };
+        cfg = { token, empresa: cfgData.empresa, senha: pw, schedule: cfgData.schedule, preferentialDesk: cfgData.preferentialDesk, speakOriginalLang: cfgData.speakOriginalLang };
         localStorage.setItem('monitorConfig', JSON.stringify(cfg));
         if (prefDeskToggle) prefDeskToggle.checked = cfg.preferentialDesk !== false;
+        if (speakOriginalToggle) speakOriginalToggle.checked = cfg.speakOriginalLang !== false;
         history.replaceState(null, '', `/monitor-attendant/?empresa=${encodeURIComponent(cfgData.empresa)}`);
         showApp(cfgData.empresa, token);
       } catch (e) {
@@ -1750,12 +1788,13 @@ function startBouncingCompanyName(text) {
         const res = await fetch(`${location.origin}/.netlify/functions/saveMonitorConfig`, {
           method: 'POST',
           headers: {'Content-Type':'application/json'},
-          body: JSON.stringify({ token, empresa: label, senha: pw, trialDays, schedule, preferentialDesk: true })
+          body: JSON.stringify({ token, empresa: label, senha: pw, trialDays, schedule, preferentialDesk: true, speakOriginalLang: true })
         });
         const { ok } = await res.json();
         if (!ok) throw new Error();
-        cfg = { token, empresa: label, senha: pw, schedule, preferentialDesk: true };
+        cfg = { token, empresa: label, senha: pw, schedule, preferentialDesk: true, speakOriginalLang: true };
         localStorage.setItem('monitorConfig', JSON.stringify(cfg));
+        if (speakOriginalToggle) speakOriginalToggle.checked = true;
         history.replaceState(null, '', `/monitor-attendant/?t=${token}&empresa=${encodeURIComponent(label)}`);
         showApp(label, token);
       } catch (e) {


### PR DESCRIPTION
## Summary
- default to the browser language for speech synthesis when original language pronunciation is disabled
- show current browser language beside the "Pronunciar nome no idioma original" toggle
- persist `speakOriginalLang` in monitor configuration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc9e8587fc8329b78433fc81b7c691