### PR TITLE
Refactor schedule utilities

### DIFF
--- a/functions/entrar.js
+++ b/functions/entrar.js
@@ -1,6 +1,7 @@
 import { Redis } from "@upstash/redis";
 import { v4 as uuidv4 } from "uuid";
 import errorHandler from "./utils/errorHandler.js";
+import { withinSchedule } from "./utils/schedule.js";
 
 const LOG_TTL = 60 * 60 * 24 * 30; // 30 days
 
@@ -43,22 +44,6 @@ export async function handler(event) {
         schedule = parsed.schedule || null;
       } catch {}
     }
-
-    const withinSchedule = (sched) => {
-      if (!sched) return true;
-      const tz   = sched.tz || "America/Sao_Paulo";
-      const now  = new Date(new Date().toLocaleString("en-US", { timeZone: tz }));
-      const day  = now.getDay();
-      const days = (sched.days || []).map(Number);
-      if (!days.includes(day)) return false;
-      if (!sched.intervals || sched.intervals.length === 0) return true;
-      const mins = now.getHours() * 60 + now.getMinutes();
-      const toMins = (t) => {
-        const [h, m] = t.split(":").map(Number);
-        return h * 60 + m;
-      };
-      return sched.intervals.some(({ start, end }) => start && end && mins >= toMins(start) && mins < toMins(end));
-    };
 
     // Cria clientId e incrementa contador de tickets
     const clientId     = uuidv4();

--- a/functions/utils/schedule.js
+++ b/functions/utils/schedule.js
@@ -1,0 +1,40 @@
+export function withinSchedule(schedule, tz) {
+  if (!schedule) return true;
+  const timezone = schedule.tz || tz || "America/Sao_Paulo";
+  const now = new Date(new Date().toLocaleString("en-US", { timeZone: timezone }));
+  const day = now.getDay();
+  const days = (schedule.days || []).map(Number);
+  if (!days.includes(day)) return false;
+  if (!schedule.intervals || schedule.intervals.length === 0) return true;
+  const mins = now.getHours() * 60 + now.getMinutes();
+  const toMins = (t) => {
+    const [h, m] = t.split(":").map(Number);
+    return h * 60 + m;
+  };
+  return schedule.intervals.some(({ start, end }) =>
+    start && end && mins >= toMins(start) && mins < toMins(end)
+  );
+}
+
+export function msUntilNextInterval(schedule, tz) {
+  if (!schedule) return null;
+  const timezone = schedule.tz || tz ||
+    (typeof Intl !== "undefined" ? Intl.DateTimeFormat().resolvedOptions().timeZone : "America/Sao_Paulo");
+  const now = new Date(new Date().toLocaleString("en-US", { timeZone: timezone }));
+  const baseIntervals = schedule.intervals && schedule.intervals.length
+    ? schedule.intervals.slice().sort((a, b) => a.start.localeCompare(b.start))
+    : [{ start: "00:00" }];
+  for (let offset = 0; offset < 7; offset++) {
+    const day = (now.getDay() + offset) % 7;
+    if (schedule.days && !schedule.days.includes(day)) continue;
+    for (const { start } of baseIntervals) {
+      if (!start) continue;
+      const [h, m] = start.split(":").map(Number);
+      const startDate = new Date(now);
+      startDate.setDate(now.getDate() + offset);
+      startDate.setHours(h, m, 0, 0);
+      if (startDate > now) return startDate - now;
+    }
+  }
+  return null;
+}

--- a/public/client/index.html
+++ b/public/client/index.html
@@ -74,6 +74,6 @@
     </div>
   </div>
 
-  <script src="js/client.js"></script>
+  <script type="module" src="js/client.js"></script>
 </body>
 </html>

--- a/public/client/js/schedule.js
+++ b/public/client/js/schedule.js
@@ -1,0 +1,40 @@
+export function withinSchedule(schedule, tz) {
+  if (!schedule) return true;
+  const timezone = schedule.tz || tz || "America/Sao_Paulo";
+  const now = new Date(new Date().toLocaleString("en-US", { timeZone: timezone }));
+  const day = now.getDay();
+  const days = (schedule.days || []).map(Number);
+  if (!days.includes(day)) return false;
+  if (!schedule.intervals || schedule.intervals.length === 0) return true;
+  const mins = now.getHours() * 60 + now.getMinutes();
+  const toMins = (t) => {
+    const [h, m] = t.split(":").map(Number);
+    return h * 60 + m;
+  };
+  return schedule.intervals.some(({ start, end }) =>
+    start && end && mins >= toMins(start) && mins < toMins(end)
+  );
+}
+
+export function msUntilNextInterval(schedule, tz) {
+  if (!schedule) return null;
+  const timezone = schedule.tz || tz ||
+    (typeof Intl !== "undefined" ? Intl.DateTimeFormat().resolvedOptions().timeZone : "America/Sao_Paulo");
+  const now = new Date(new Date().toLocaleString("en-US", { timeZone: timezone }));
+  const baseIntervals = schedule.intervals && schedule.intervals.length
+    ? schedule.intervals.slice().sort((a, b) => a.start.localeCompare(b.start))
+    : [{ start: "00:00" }];
+  for (let offset = 0; offset < 7; offset++) {
+    const day = (now.getDay() + offset) % 7;
+    if (schedule.days && !schedule.days.includes(day)) continue;
+    for (const { start } of baseIntervals) {
+      if (!start) continue;
+      const [h, m] = start.split(":").map(Number);
+      const startDate = new Date(now);
+      startDate.setDate(now.getDate() + offset);
+      startDate.setHours(h, m, 0, 0);
+      if (startDate > now) return startDate - now;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add `schedule.js` helper with `withinSchedule` and `msUntilNextInterval`
- refactor server functions to use shared `withinSchedule`
- expose schedule helpers on client and update polling logic

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcbd47720483299c9ef08ef0ddd80f