### PR TITLE
refactor: centralize sanitizeEmpresa utility

### DIFF
--- a/functions/deleteMonitorConfig.js
+++ b/functions/deleteMonitorConfig.js
@@ -1,22 +1,14 @@
 // functions/deleteMonitorConfig.js
 
-const { Redis } = require('@upstash/redis');
+import { Redis } from '@upstash/redis';
+import sanitizeEmpresa from './utils/sanitizeEmpresa.js';
 
 const redis = new Redis({
   url: process.env.UPSTASH_REDIS_REST_URL,
   token: process.env.UPSTASH_REDIS_REST_TOKEN
 });
 
-function sanitizeEmpresa(name) {
-  return name
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]/g, '');
-}
-
-exports.handler = async (event) => {
+export async function handler(event) {
   if (event.httpMethod !== 'POST') {
     return {
       statusCode: 405,
@@ -84,4 +76,4 @@ exports.handler = async (event) => {
       body: JSON.stringify({ error: err.message })
     };
   }
-};
+}

--- a/functions/extendSubscription.js
+++ b/functions/extendSubscription.js
@@ -1,21 +1,13 @@
 // functions/extendSubscription.js
-const { Redis } = require('@upstash/redis');
+import { Redis } from '@upstash/redis';
+import sanitizeEmpresa from './utils/sanitizeEmpresa.js';
 
 const redisExt = new Redis({
   url: process.env.UPSTASH_REDIS_REST_URL,
   token: process.env.UPSTASH_REDIS_REST_TOKEN
 });
 
-function sanitizeEmpresa(name) {
-  return name
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]/g, '');
-}
-
-exports.handler = async (event) => {
+export async function handler(event) {
   if (event.httpMethod !== 'POST') {
     return { statusCode: 405, body: JSON.stringify({ error: 'Método não permitido' }) };
   }
@@ -69,4 +61,4 @@ exports.handler = async (event) => {
       body: JSON.stringify({ error: err.message })
     };
   }
-};
+}

--- a/functions/getMonitorToken.js
+++ b/functions/getMonitorToken.js
@@ -1,14 +1,6 @@
 import { Redis } from '@upstash/redis';
 import bcrypt from 'bcryptjs';
-
-function sanitizeEmpresa(name) {
-  return name
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]/g, '');
-}
+import sanitizeEmpresa from './utils/sanitizeEmpresa.js';
 
 export async function handler(event) {
   if (event.httpMethod !== 'POST') {

--- a/functions/saveMonitorConfig.js
+++ b/functions/saveMonitorConfig.js
@@ -1,22 +1,14 @@
 // functions/saveMonitorConfig.js
-const { Redis } = require('@upstash/redis');
-const bcrypt = require('bcryptjs');
+import { Redis } from '@upstash/redis';
+import bcrypt from 'bcryptjs';
+import sanitizeEmpresa from './utils/sanitizeEmpresa.js';
 
 const redis = new Redis({
   url: process.env.UPSTASH_REDIS_REST_URL,
   token: process.env.UPSTASH_REDIS_REST_TOKEN
 });
 
-function sanitizeEmpresa(name) {
-  return name
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]/g, '');
-}
-
-exports.handler = async (event) => {
+export async function handler(event) {
   if (event.httpMethod !== 'POST') {
     return { statusCode: 405, body: JSON.stringify({ error: 'Método não permitido' }) };
   }
@@ -75,4 +67,4 @@ exports.handler = async (event) => {
       body: JSON.stringify({ error: err.message })
     };
   }
-};
+}

--- a/functions/utils/sanitizeEmpresa.js
+++ b/functions/utils/sanitizeEmpresa.js
@@ -1,0 +1,9 @@
+export default function sanitizeEmpresa(name) {
+  return name
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]/g, '');
+}
+


### PR DESCRIPTION
## Summary
- centralize sanitizeEmpresa logic into a reusable utility
- refactor monitor-related functions to use shared sanitizer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcc790bebc8329b176d934d3c79d52