### PR TITLE
Add alert sound and wake lock to monitor

### DIFF
--- a/public/monitor/css/monitor.css
+++ b/public/monitor/css/monitor.css
@@ -51,7 +51,7 @@ body.view-mobile {
   max-width: 480px;
 }
 .mobile-card .empresa {
-  font-size: 1.25rem;
+  font-size: 1.75rem;
   margin-bottom: .5rem;
 }
 .mobile-card .label {
@@ -96,6 +96,10 @@ body.view-tv {
 }
 .tv-header .logo img {
   height: 40px;
+}
+.tv-header .company-name {
+  font-size: 2rem;
+  font-weight: 600;
 }
 .tv-main {
   flex: 1;


### PR DESCRIPTION
## Summary
- Play audio and speak ticket numbers on monitor
- Keep mobile monitor awake and remove PDF button
- Enlarge company name in monitor views

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcd9fedf288329a1ef573d10a6cd72