### PR TITLE
feat(monitor): TTS fala o nome do ticket por último quando disponível

### DIFF
--- a/public/monitor/js/utils/speech.js
+++ b/public/monitor/js/utils/speech.js
@@ -10,3 +10,22 @@ export function speak(text, rate = 1, pitch = 1) {
   utter.pitch = pitch;
   speechSynthesis.speak(utter);
 }
+
+export function buildSpeechText(n, opts) {
+  const parts = [];
+
+  if (n.tipo === 'Preferencial') parts.push('Preferencial');
+  parts.push(`senha ${n.number}`);
+
+  if (opts.sayGuiche && n.guiche) parts.push(`Guichê ${n.guiche}`);
+
+  let text = parts.join(', ') + '.';
+
+  const raw = (n.name ?? '').replace(/\s+/g, ' ').trim();
+  const name = raw.slice(0, 80);
+  if (name.length > 1) {
+    text += ' ' + name;
+  }
+
+  return text;
+}


### PR DESCRIPTION
## Summary
- speak ticket name at the end of monitor TTS call when provided
- sanitize and limit name length to avoid long texts
- reuse existing audio toggles and speech synthesis

## Testing
- `npm test` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bde3e6d4a883298e603cba10b5e0c3