### PR TITLE
feat(monitor/tts): pausa antes do guichê e locução profissional

### DIFF
--- a/public/monitor/js/utils/speech.js
+++ b/public/monitor/js/utils/speech.js
@@ -17,16 +17,24 @@ export function buildSpeechText(n, opts) {
   if (n.tipo === 'Preferencial') parts.push('Preferencial');
   parts.push(`senha ${n.number}`);
 
+  // Fecha a primeira frase com ponto para garantir pausa
   let text = parts.join(', ') + '.';
 
-  const raw = (n.name ?? '').replace(/\s+/g, ' ').trim();
-  const name = raw.slice(0, 80);
+  // Sanitiza e adiciona nome com vírgula ao final
+  const rawName = (n.name ?? '').replace(/\s+/g, ' ').trim();
+  const name = rawName.slice(0, 80);
   if (name.length > 1) {
-    text += ' ' + name;
+    text += ` ${name},`;
   }
 
+  // Guichê: apenas o conteúdo, sem a palavra
   const g = (n.guiche ?? '').toString().trim();
-  if (opts.sayGuiche && g) text += ' ' + g;
+  if (opts.sayGuiche && g) {
+    text += ` ${g}.`;
+  } else if (name.length > 1) {
+    // Se não houver guichê, finaliza após o nome
+    text = text.replace(/,$/, '.');
+  }
 
   return text;
 }


### PR DESCRIPTION
## Summary
- refine TTS phrase structure on monitor for clearer rhythm and professional speech
- sanitize and truncate names with comma, add guichê content only when enabled

## Testing
- ⚠️ `npm test` *(missing script: test)*
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdeca27e508329a87906064fc9cf54