### PR TITLE
fix(monitor): parar polling no reset e manter desativado após reload

### DIFF
--- a/public/monitor/js/utils/monitor-polling.js
+++ b/public/monitor/js/utils/monitor-polling.js
@@ -1,0 +1,42 @@
+// Global helpers to manage polling timers and abort signals
+let pollingIntervalId = null;
+let kpiIntervalId = null;
+let aborter = null;
+
+export function startPolling(fn, ms = 4000) {
+  if (pollingIntervalId != null) return;
+  pollingIntervalId = window.setInterval(fn, ms);
+}
+
+export function startKpi(fn, ms = 1000) {
+  if (kpiIntervalId != null) return;
+  kpiIntervalId = window.setInterval(fn, ms);
+}
+
+export function stopAllPolling() {
+  if (pollingIntervalId != null) {
+    clearInterval(pollingIntervalId);
+    pollingIntervalId = null;
+  }
+  if (kpiIntervalId != null) {
+    clearInterval(kpiIntervalId);
+    kpiIntervalId = null;
+  }
+  if (aborter) {
+    try { aborter.abort(); } catch (e) {}
+    aborter = null;
+  }
+}
+
+export function newAborter() {
+  aborter = new AbortController();
+  return aborter.signal;
+}
+
+const FLAG = 'xsn_monitor_polling';
+export function setPollingFlag(on) {
+  sessionStorage.setItem(FLAG, on ? 'on' : 'off');
+}
+export function isPollingOn() {
+  return sessionStorage.getItem(FLAG) !== 'off';
+}


### PR DESCRIPTION
## Summary
- add global helpers to control monitor polling timers and abort pending requests
- stop and disable polling on reset, with banner and CTA to re-enable after reload
- wire fetch calls to AbortController to avoid extra updates and duplicate polling

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be0c0224208329a7e3ab5019910879