### PR TITLE
fix: show all pending tickets

### DIFF
--- a/functions/status.js
+++ b/functions/status.js
@@ -105,17 +105,19 @@ export async function handler(event) {
   const prioritySet  = new Set(priorityNums);
 
   let waiting = 0;
-  for (let i = callCounter + 1; i <= ticketCounter; i++) {
+  for (let i = 1; i <= ticketCounter; i++) {
     if (
-      i !== currentCall &&
-      !cancelledSet.has(i) &&
-      !missedSet.has(i) &&
-      !attendedSet.has(i) &&
-      !skippedSet.has(i) &&
-      !offHoursSet.has(i)
+      i === currentCall ||
+      cancelledSet.has(i) ||
+      missedSet.has(i) ||
+      attendedSet.has(i) ||
+      skippedSet.has(i) ||
+      offHoursSet.has(i) ||
+      (i <= callCounter && !prioritySet.has(i))
     ) {
-      waiting++;
+      continue;
     }
+    waiting++;
   }
 
   return {

--- a/public/client/js/client.js
+++ b/public/client/js/client.js
@@ -245,19 +245,22 @@ async function checkStatus() {
   if (status.preferentialDesk !== false) {
     if (isPriority) {
       label = 'Preferenciais à sua frente:';
-      for (let n = callCounter + 1; n < ticketNumber; n++) {
+      for (let n = 1; n < ticketNumber; n++) {
+        if (n === currentCall) continue;
         if (priNums.includes(n) && !removed.has(n)) ahead++;
       }
     } else {
       label = 'Normais à sua frente:';
-      for (let n = callCounter + 1; n < ticketNumber; n++) {
+      for (let n = 1; n < ticketNumber; n++) {
+        if (n === currentCall) continue;
         if (!priNums.includes(n) && !removed.has(n)) ahead++;
       }
     }
   } else {
     label = 'À sua frente:';
-    for (let n = callCounter + 1; n < ticketNumber; n++) {
-      if (n !== currentCall && !removed.has(n)) ahead++;
+    for (let n = 1; n < ticketNumber; n++) {
+      if (n === currentCall || removed.has(n)) continue;
+      ahead++;
     }
   }
   renderAheadCount(ahead, label);

--- a/public/monitor/js/monitor.js
+++ b/public/monitor/js/monitor.js
@@ -223,9 +223,17 @@ function computeQueues(data) {
   const priority = new Set(data.priorityNumbers || []);
   const normals = [];
   const prios = [];
-  for (let i = data.callCounter + 1; i <= data.ticketCounter; i++) {
+  for (let i = 1; i <= data.ticketCounter; i++) {
     if (i === data.currentCall) continue;
-    if (cancelled.has(i) || missed.has(i) || attended.has(i) || skipped.has(i) || offHours.has(i)) continue;
+    if (
+      cancelled.has(i) ||
+      missed.has(i) ||
+      attended.has(i) ||
+      skipped.has(i) ||
+      offHours.has(i)
+    )
+      continue;
+    if (i <= data.callCounter && !priority.has(i)) continue;
     if (priority.has(i)) prios.push(i);
     else normals.push(i);
   }


### PR DESCRIPTION
## Summary
- ensure monitor queue includes pending tickets with lower numbers
- count waiting tickets across entire range in status API
- adjust client ahead calculation to account for previously skipped numbers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf6d7dc2ac832987fc1f29c407a5ac