### PR TITLE
feat: inline duplicate correction in import list

### DIFF
--- a/public/monitor-attendant/css/monitor-attendant.css
+++ b/public/monitor-attendant/css/monitor-attendant.css
@@ -784,6 +784,20 @@ body {
   color: var(--danger);
 }
 
+#import-modal .dup-row td,
+#import-modal .dup-input {
+  border-color: #e11d48;
+}
+
+#import-modal .dup-badge {
+  margin-left: 0.5rem;
+}
+
+#import-confirm:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 /* Modal de edição de horário */
 #schedule-modal {
   position: fixed;

--- a/public/monitor-attendant/index.html
+++ b/public/monitor-attendant/index.html
@@ -321,10 +321,7 @@
       </div>
       <div id="import-step-preview" hidden>
         <p class="note" id="import-note">A lista será adicionada ao FINAL da Fila Virtual, mantendo a ordem do arquivo.</p>
-        <div id="import-dup-box" class="error" hidden>
-          Há nomes idênticos (ignorando *). Para evitar confusão no Monitor, edite sua lista e acrescente um diferencial (sobrenome, apelido ou código).
-          <table id="import-dup-table"></table>
-        </div>
+        <div id="import-dup-box" class="error" hidden></div>
         <table id="import-preview-table" title="Marque preferenciais com * no final do nome. Nomes devem ser únicos."></table>
         <div class="import-counts">Total <span id="import-count-total">0</span> | Preferenciais <span id="import-count-pref">0</span> | Normais <span id="import-count-normal">0</span></div>
         <div id="import-progress" class="import-progress" hidden>


### PR DESCRIPTION
## Summary
- allow resolving duplicate client names inline during import
- highlight duplicate entries and disable import until resolved
- support keyboard shortcuts for navigating and confirming

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf7ba90b9c8329a20586010f82548c