### PR TITLE
Stop monitor polling after reset

### DIFF
--- a/public/monitor/js/monitor.js
+++ b/public/monitor/js/monitor.js
@@ -292,6 +292,11 @@ async function fetchCurrent() {
   try {
     const url = '/.netlify/functions/status' + (tenantId ? `?t=${tenantId}` : '');
     const res = await fetch(url);
+    if (res.status === 404) {
+      stopPolling();
+      window.location.href = '/monitor/';
+      return;
+    }
     const data = await res.json();
     const { currentCall, names = {}, timestamp, attendant, currentCallPriority = 0 } = data;
     currentEl.textContent = currentCall || '—';
@@ -345,7 +350,7 @@ function stopPolling() {
 }
 
 function maybeStartPolling() {
-  if (audioUnlocked && !document.hidden && !intervalId) {
+  if (tenantId && audioUnlocked && !document.hidden && !intervalId) {
     startPolling();
   }
 }


### PR DESCRIPTION
## Summary
- Stop monitor polling when `status` returns 404 and redirect to initial screen
- Avoid starting polling when monitor token is absent

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check public/monitor/js/monitor.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1d4dd55ec83299dfc0cf22bacab21