### PR TITLE
Padroniza mensagens de erro em português

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Funções serverless e front-end para a fila virtual SuaVez.
 
+## Idioma
+
+Todas as mensagens do projeto estão padronizadas em português.
+
 ## Funcionalidades
 
 ### Para Clientes

--- a/functions/atendido.js
+++ b/functions/atendido.js
@@ -7,7 +7,7 @@ export async function handler(event) {
   const url      = new URL(event.rawUrl);
   const tenantId = url.searchParams.get("t");
   if (!tenantId) {
-    return error(400, "Missing tenantId");
+    return error(400, "tenantId ausente");
   }
 
   const redis  = Redis.fromEnv();
@@ -16,11 +16,11 @@ export async function handler(event) {
     `monitor:${tenantId}`
   );
   if (!pwHash && !monitor) {
-    return error(404, "Invalid link");
+    return error(404, "Link inválido");
   }
   const { ticket } = JSON.parse(event.body || "{}");
   if (!ticket) {
-    return error(400, "Missing ticket");
+    return error(400, "Ticket ausente");
   }
 
   const prefix = `tenant:${tenantId}:`;

--- a/functions/atendidos.js
+++ b/functions/atendidos.js
@@ -5,7 +5,7 @@ export async function handler(event) {
   const url      = new URL(event.rawUrl);
   const tenantId = url.searchParams.get("t");
   if (!tenantId) {
-    return error(400, "Missing tenantId");
+    return error(400, "tenantId ausente");
   }
 
   const redis  = Redis.fromEnv();
@@ -14,7 +14,7 @@ export async function handler(event) {
     `monitor:${tenantId}`
   );
   if (!pwHash && !monitor) {
-    return error(404, "Invalid link");
+    return error(404, "Link inválido");
   }
   const prefix = `tenant:${tenantId}:`;
 

--- a/functions/cancelClone.js
+++ b/functions/cancelClone.js
@@ -5,13 +5,13 @@ export async function handler(event) {
   try {
     const { token, cloneId } = JSON.parse(event.body || '{}');
     if (!token || !cloneId) {
-      return error(400, 'Missing fields');
+      return error(400, 'Campos obrigatórios ausentes');
     }
     const redis = Redis.fromEnv();
     await redis.srem(`tenant:${token}:clones`, cloneId);
     return json(200, { ok: true });
   } catch (e) {
     console.error('cancelClone error', e);
-    return error(500, 'Server error');
+    return error(500, 'Erro no servidor');
   }
 }

--- a/functions/cancelados.js
+++ b/functions/cancelados.js
@@ -5,7 +5,7 @@ export async function handler(event) {
   const url      = new URL(event.rawUrl);
   const tenantId = url.searchParams.get("t");
   if (!tenantId) {
-    return error(400, "Missing tenantId");
+    return error(400, "tenantId ausente");
   }
 
   const redis  = Redis.fromEnv();
@@ -14,7 +14,7 @@ export async function handler(event) {
     `monitor:${tenantId}`
   );
   if (!pwHash && !monitor) {
-    return error(404, "Invalid link");
+    return error(404, "Link inválido");
   }
   const prefix = `tenant:${tenantId}:`;
 

--- a/functions/cancelar.js
+++ b/functions/cancelar.js
@@ -7,7 +7,7 @@ export async function handler(event) {
   const url      = new URL(event.rawUrl);
   const tenantId = url.searchParams.get("t");
   if (!tenantId) {
-    return error(400, "Missing tenantId");
+    return error(400, "tenantId ausente");
   }
 
   const redis  = Redis.fromEnv();
@@ -16,7 +16,7 @@ export async function handler(event) {
     `monitor:${tenantId}`
   );
   if (!pwHash && !monitor) {
-    return error(404, "Invalid link");
+    return error(404, "Link inválido");
   }
   const prefix = `tenant:${tenantId}:`;
   const { clientId, ticket, reason = "client", duration } = JSON.parse(event.body || "{}");

--- a/functions/chamar.js
+++ b/functions/chamar.js
@@ -9,7 +9,7 @@ export async function handler(event) {
     const url      = new URL(event.rawUrl);
     const tenantId = url.searchParams.get("t");
     if (!tenantId) {
-      return error(400, "Missing tenantId");
+      return error(400, "tenantId ausente");
     }
 
     const redis     = Redis.fromEnv();
@@ -18,7 +18,7 @@ export async function handler(event) {
       `monitor:${tenantId}`
     );
     if (!pwHash && !monitor) {
-      return error(404, "Invalid link");
+      return error(404, "Link inválido");
     }
     const prefix    = `tenant:${tenantId}:`;
     const paramNum  = url.searchParams.get("num");

--- a/functions/changePassword.js
+++ b/functions/changePassword.js
@@ -6,12 +6,12 @@ export async function handler(event) {
   try {
     const { token, senhaAtual, novaSenha } = JSON.parse(event.body || '{}');
     if (!token || !senhaAtual || !novaSenha) {
-      return error(400, 'Missing fields');
+      return error(400, 'Campos obrigatórios ausentes');
     }
     const redis = Redis.fromEnv();
     const pwHash = await redis.get(`tenant:${token}:pwHash`);
     if (!pwHash) {
-      return error(404, 'Invalid token');
+      return error(404, 'Token inválido');
     }
     const valid = await bcrypt.compare(senhaAtual, pwHash);
     if (!valid) {
@@ -23,6 +23,6 @@ export async function handler(event) {
     return json(200, { ok: true });
   } catch (e) {
     console.error('changePassword error', e);
-    return error(500, 'Server error');
+    return error(500, 'Erro no servidor');
   }
 }

--- a/functions/enqueueBatch.js
+++ b/functions/enqueueBatch.js
@@ -9,7 +9,7 @@ export async function handler(event) {
     const url = new URL(event.rawUrl);
     const tenantId = url.searchParams.get("t");
     if (!tenantId) {
-      return error(400, "Missing tenantId");
+      return error(400, "tenantId ausente");
     }
 
     let body = {};
@@ -19,7 +19,7 @@ export async function handler(event) {
 
     const items = Array.isArray(body.items) ? body.items : [];
     if (items.length === 0) {
-      return error(400, "Empty list");
+      return error(400, "Lista vazia");
     }
 
     const redis = Redis.fromEnv();
@@ -28,7 +28,7 @@ export async function handler(event) {
       `monitor:${tenantId}`
     );
     if (!pwHash && !monitor) {
-      return error(404, "Invalid link");
+      return error(404, "Link inválido");
     }
 
     const prefix = `tenant:${tenantId}:`;

--- a/functions/entrar.js
+++ b/functions/entrar.js
@@ -11,7 +11,7 @@ export async function handler(event) {
     const url      = new URL(event.rawUrl);
     const tenantId = url.searchParams.get("t");
     if (!tenantId) {
-      return error(400, "Missing tenantId");
+      return error(400, "tenantId ausente");
     }
 
     let body = {};
@@ -30,7 +30,7 @@ export async function handler(event) {
       `tenant:${tenantId}:schedule`
     );
     if (!pwHash && !monitor) {
-      return error(404, "Invalid link");
+      return error(404, "Link inválido");
     }
     const prefix = `tenant:${tenantId}:`;
 

--- a/functions/getMonitorToken.js
+++ b/functions/getMonitorToken.js
@@ -44,7 +44,7 @@ export async function handler(event) {
     redis = Redis.fromEnv();
   } catch (err) {
     console.error('Redis init error:', err);
-    return error(500, 'Server configuration error');
+    return error(500, 'Erro de configuração do servidor');
   }
 
   try {

--- a/functions/getSchedule.js
+++ b/functions/getSchedule.js
@@ -9,7 +9,7 @@ const redis = new Redis({
 export async function handler(event) {
   const token = event.queryStringParameters && event.queryStringParameters.t;
   if (!token) {
-    return error(400, 'Missing token');
+    return error(400, 'Token ausente');
   }
   try {
     const [schedRaw, monitorRaw, pwHash] = await redis.mget(
@@ -18,7 +18,7 @@ export async function handler(event) {
       `tenant:${token}:pwHash`
     );
     if (!pwHash && !monitorRaw) {
-      return error(404, 'Invalid link');
+      return error(404, 'Link inválido');
     }
     if (schedRaw) {
       let parsed;

--- a/functions/listClones.js
+++ b/functions/listClones.js
@@ -6,13 +6,13 @@ export async function handler(event) {
     const url = new URL(event.rawUrl);
     const token = url.searchParams.get('t');
     if (!token) {
-      return error(400, 'Missing token');
+      return error(400, 'Token ausente');
     }
     const redis = Redis.fromEnv();
     const clones = await redis.smembers(`tenant:${token}:clones`);
     return json(200, { clones });
   } catch (e) {
     console.error('listClones error', e);
-    return error(500, 'Server error');
+    return error(500, 'Erro no servidor');
   }
 }

--- a/functions/manualTicket.js
+++ b/functions/manualTicket.js
@@ -7,7 +7,7 @@ export async function handler(event) {
   const url = new URL(event.rawUrl);
   const tenantId = url.searchParams.get("t");
   if (!tenantId) {
-    return error(400, "Missing tenantId");
+    return error(400, "tenantId ausente");
   }
 
   const redis = Redis.fromEnv();
@@ -16,7 +16,7 @@ export async function handler(event) {
     `monitor:${tenantId}`
   );
   if (!pwHash && !monitor) {
-    return error(404, "Invalid link");
+    return error(404, "Link inválido");
   }
   const { name = "", priority: bodyPriority } = JSON.parse(event.body || "{}");
   const priorityParam = bodyPriority ?? url.searchParams.get("priority");

--- a/functions/registerClone.js
+++ b/functions/registerClone.js
@@ -5,13 +5,13 @@ export async function handler(event) {
   try {
     const { token, cloneId } = JSON.parse(event.body || '{}');
     if (!token || !cloneId) {
-      return error(400, 'Missing fields');
+      return error(400, 'Campos obrigatórios ausentes');
     }
     const redis = Redis.fromEnv();
     await redis.sadd(`tenant:${token}:clones`, cloneId);
     return json(200, { ok: true });
   } catch (e) {
     console.error('registerClone error', e);
-    return error(500, 'Server error');
+    return error(500, 'Erro no servidor');
   }
 }

--- a/functions/registerMonitor.js
+++ b/functions/registerMonitor.js
@@ -7,7 +7,7 @@ export async function handler(event) {
   try {
     const { tenantId, label, password } = JSON.parse(event.body || '{}');
     if (!tenantId || !label || !password) {
-      return error(400, 'Missing fields');
+      return error(400, 'Campos obrigatórios ausentes');
     }
 
     // Cria hash seguro da senha
@@ -30,6 +30,6 @@ export async function handler(event) {
     return json(200, { success: true, tenantId });
   } catch (err) {
     console.error('registerMonitor error', err);
-    return error(500, 'Server error');
+    return error(500, 'Erro no servidor');
   }
 }

--- a/functions/report.js
+++ b/functions/report.js
@@ -8,7 +8,7 @@ export async function handler(event) {
     const url = new URL(event.rawUrl);
     const tenantId = url.searchParams.get("t");
     if (!tenantId) {
-      return error(400, "Missing tenantId");
+      return error(400, "tenantId ausente");
     }
 
     const redis = Redis.fromEnv();
@@ -17,7 +17,7 @@ export async function handler(event) {
       `monitor:${tenantId}`
     );
     if (!pwHash && !monitor) {
-      return error(404, "Invalid link");
+      return error(404, "Link inválido");
     }
     const prefix = `tenant:${tenantId}:`;
 

--- a/functions/reset.js
+++ b/functions/reset.js
@@ -11,7 +11,7 @@ export async function handler(event) {
     const tenantId   = url.searchParams.get("t");
     const attendant  = url.searchParams.get("id") || "";
     if (!tenantId) {
-      return error(400, "Missing tenantId");
+      return error(400, "tenantId ausente");
     }
 
     const redis  = Redis.fromEnv();
@@ -20,7 +20,7 @@ export async function handler(event) {
       `monitor:${tenantId}`
     );
     if (!pwHash && !monitor) {
-      return error(404, "Invalid link");
+      return error(404, "Link inválido");
     }
     const prefix = `tenant:${tenantId}:`;
     const ts     = Date.now();

--- a/functions/setTicketCounter.js
+++ b/functions/setTicketCounter.js
@@ -7,12 +7,12 @@ export async function handler(event) {
     const url = new URL(event.rawUrl);
     const tenantId = url.searchParams.get("t");
     if (!tenantId) {
-      return error(400, "Missing tenantId");
+      return error(400, "tenantId ausente");
     }
     const { ticket } = JSON.parse(event.body || "{}");
     const nextTicket = Number(ticket);
     if (!nextTicket) {
-      return error(400, "Missing ticket");
+      return error(400, "Ticket ausente");
     }
     const redis = Redis.fromEnv();
     const [pwHash, monitor] = await redis.mget(
@@ -20,13 +20,13 @@ export async function handler(event) {
       `monitor:${tenantId}`
     );
     if (!pwHash && !monitor) {
-      return error(404, "Invalid link");
+      return error(404, "Link inválido");
     }
     const prefix = `tenant:${tenantId}:`;
     const last   = Number(await redis.get(prefix + "ticketCounter") || 0);
     const called = Number(await redis.get(prefix + "callCounter") || 0);
     if (nextTicket <= last) {
-      return error(400, "Ticket must be greater than last");
+      return error(400, "O ticket deve ser maior que o último");
     }
 
     const gap = nextTicket - last - 1; // números pulados

--- a/functions/status.js
+++ b/functions/status.js
@@ -8,7 +8,7 @@ export async function handler(event) {
   const url      = new URL(event.rawUrl);
   const tenantId = url.searchParams.get("t");
   if (!tenantId) {
-    return error(400, "Missing tenantId");
+    return error(400, "tenantId ausente");
   }
 
   const redis  = Redis.fromEnv();
@@ -18,7 +18,7 @@ export async function handler(event) {
     `tenant:${tenantId}:schedule`
   );
   if (!pwHash && !monitorRaw) {
-    return error(404, "Invalid link");
+    return error(404, "Link inválido");
   }
   const prefix = `tenant:${tenantId}:`;
 

--- a/functions/utils/errorHandler.js
+++ b/functions/utils/errorHandler.js
@@ -2,5 +2,5 @@ import { error as jsonError } from './response.js';
 
 export default function errorHandler(error) {
   console.error(error);
-  return jsonError(500, 'Server error');
+  return jsonError(500, 'Erro no servidor');
 }

--- a/functions/validatePassword.js
+++ b/functions/validatePassword.js
@@ -9,7 +9,7 @@ export async function handler(event) {
     const tenantId  = url.searchParams.get('t');
     const { password } = JSON.parse(event.body || '{}');
     if (!tenantId || !password) {
-      return error(400, 'Invalid request');
+      return error(400, 'Solicitação inválida');
     }
 
     const redis = Redis.fromEnv();
@@ -18,7 +18,7 @@ export async function handler(event) {
       `monitor:${tenantId}`
     );
     if (!storedHash && !monitor) {
-      return error(404, 'Invalid link');
+      return error(404, 'Link inválido');
     }
     if (!storedHash) {
       return json(404, { valid: false });
@@ -33,6 +33,6 @@ export async function handler(event) {
     return json(200, { valid, label });
   } catch (err) {
     console.error('validatePassword error', err);
-    return error(500, 'Server error');
+    return error(500, 'Erro no servidor');
   }
 }


### PR DESCRIPTION
## Resumo
- Define português como idioma oficial no README
- Converte mensagens de erro das funções serverless para português

## Testes
- `npm test` *(falhou: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c52ec6ce2883299f7f6d1fe050af39