### PR TITLE
Centralize error handling across serverless functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ Todas as mensagens do projeto estão padronizadas em português.
 - Controle total sobre a participação: pode cancelar a qualquer momento ou silenciar alertas.
 - Atendimento mais ágil graças ao painel de gestão do atendente, reduzindo o tempo de espera.
 
+## Tratamento de Erros
+
+Todas as funções utilizam um `errorHandler` compartilhado que registra problemas e retorna respostas JSON padronizadas no formato:
+
+```json
+{ "error": "mensagem" }
+```
+
+Erros internos do servidor resultam em status `500` com a mensagem genérica `Erro no servidor`.
+
 ## Reset de Monitor
 
 A função `deleteMonitorConfig` apaga o registro do monitor e **todas** as chaves `tenant:{token}:*` associadas no Redis.

--- a/functions/atendido.js
+++ b/functions/atendido.js
@@ -1,73 +1,78 @@
 import { Redis } from "@upstash/redis";
+import errorHandler from "./utils/errorHandler.js";
 import { error, json } from "./utils/response.js";
 
 const LOG_TTL = 60 * 60 * 24 * 30; // 30 days
 
 export async function handler(event) {
-  const url      = new URL(event.rawUrl);
-  const tenantId = url.searchParams.get("t");
-  if (!tenantId) {
-    return error(400, "tenantId ausente");
+  try {
+    const url      = new URL(event.rawUrl);
+    const tenantId = url.searchParams.get("t");
+    if (!tenantId) {
+      return error(400, "tenantId ausente");
+    }
+
+    const redis  = Redis.fromEnv();
+    const [pwHash, monitor] = await redis.mget(
+      `tenant:${tenantId}:pwHash`,
+      `monitor:${tenantId}`
+    );
+    if (!pwHash && !monitor) {
+      return error(404, "Link inválido");
+    }
+    const { ticket } = JSON.parse(event.body || "{}");
+    if (!ticket) {
+      return error(400, "Ticket ausente");
+    }
+
+    const prefix = `tenant:${tenantId}:`;
+
+    const ticketStr = String(ticket);
+    await redis.sadd(prefix + "attendedSet", ticketStr);
+    await redis.srem(prefix + "prioritySet", ticketStr);
+    await redis.srem(prefix + "cancelledSet", ticketStr);
+    await redis.srem(prefix + "missedSet", ticketStr);
+
+    // Remove eventuais registros de perda de vez
+    const missRaw = await redis.lrange(prefix + "log:cancelled", 0, -1);
+    for (const item of missRaw) {
+      try {
+        const obj = JSON.parse(item);
+        if (obj.ticket === Number(ticket) && obj.reason === "missed") {
+          await redis.lrem(prefix + "log:cancelled", 0, item);
+        }
+      } catch {}
+    }
+
+    const [callTsRaw, waitRaw] = await redis.mget(
+      prefix + "currentCallTs",
+      prefix + `wait:${ticket}`
+    );
+    const callTs  = Number(callTsRaw || 0);
+    const duration = callTs ? Date.now() - callTs : 0;
+    const wait     = Number(waitRaw || 0);
+    await redis.del(prefix + `wait:${ticket}`);
+
+    // Limpa a chamada atual para evitar que o número seja marcado como perdido
+    await redis.mset({
+      [prefix + "currentCall"]: 0,
+      [prefix + "currentCallTs"]: 0,
+      [prefix + "currentCallPriority"]: 0,
+    });
+    await redis.del(prefix + "currentAttendant");
+
+    // registra a finalização do atendimento
+    const ts = Date.now();
+    await redis.set(prefix + `attendedTime:${ticket}`, ts);
+    await redis.lpush(
+      prefix + "log:attended",
+      JSON.stringify({ ticket: Number(ticket), ts, duration, wait })
+    );
+    await redis.ltrim(prefix + "log:attended", 0, 999);
+    await redis.expire(prefix + "log:attended", LOG_TTL);
+
+    return json(200, { attended: true, ticket: Number(ticket), duration, wait, ts });
+  } catch (error) {
+    return errorHandler(error);
   }
-
-  const redis  = Redis.fromEnv();
-  const [pwHash, monitor] = await redis.mget(
-    `tenant:${tenantId}:pwHash`,
-    `monitor:${tenantId}`
-  );
-  if (!pwHash && !monitor) {
-    return error(404, "Link inválido");
-  }
-  const { ticket } = JSON.parse(event.body || "{}");
-  if (!ticket) {
-    return error(400, "Ticket ausente");
-  }
-
-  const prefix = `tenant:${tenantId}:`;
-
-  const ticketStr = String(ticket);
-  await redis.sadd(prefix + "attendedSet", ticketStr);
-  await redis.srem(prefix + "prioritySet", ticketStr);
-  await redis.srem(prefix + "cancelledSet", ticketStr);
-  await redis.srem(prefix + "missedSet", ticketStr);
-
-  // Remove eventuais registros de perda de vez
-  const missRaw = await redis.lrange(prefix + "log:cancelled", 0, -1);
-  for (const item of missRaw) {
-    try {
-      const obj = JSON.parse(item);
-      if (obj.ticket === Number(ticket) && obj.reason === "missed") {
-        await redis.lrem(prefix + "log:cancelled", 0, item);
-      }
-    } catch {}
-  }
-
-  const [callTsRaw, waitRaw] = await redis.mget(
-    prefix + "currentCallTs",
-    prefix + `wait:${ticket}`
-  );
-  const callTs  = Number(callTsRaw || 0);
-  const duration = callTs ? Date.now() - callTs : 0;
-  const wait     = Number(waitRaw || 0);
-  await redis.del(prefix + `wait:${ticket}`);
-
-  // Limpa a chamada atual para evitar que o número seja marcado como perdido
-  await redis.mset({
-    [prefix + "currentCall"]: 0,
-    [prefix + "currentCallTs"]: 0,
-    [prefix + "currentCallPriority"]: 0,
-  });
-  await redis.del(prefix + "currentAttendant");
-
-  // registra a finalização do atendimento
-  const ts = Date.now();
-  await redis.set(prefix + `attendedTime:${ticket}`, ts);
-  await redis.lpush(
-    prefix + "log:attended",
-    JSON.stringify({ ticket: Number(ticket), ts, duration, wait })
-  );
-  await redis.ltrim(prefix + "log:attended", 0, 999);
-  await redis.expire(prefix + "log:attended", LOG_TTL);
-
-  return json(200, { attended: true, ticket: Number(ticket), duration, wait, ts });
 }

--- a/functions/atendidos.js
+++ b/functions/atendidos.js
@@ -1,29 +1,34 @@
 import { Redis } from "@upstash/redis";
+import errorHandler from "./utils/errorHandler.js";
 import { error, json } from "./utils/response.js";
 
 export async function handler(event) {
-  const url      = new URL(event.rawUrl);
-  const tenantId = url.searchParams.get("t");
-  if (!tenantId) {
-    return error(400, "tenantId ausente");
+  try {
+    const url      = new URL(event.rawUrl);
+    const tenantId = url.searchParams.get("t");
+    if (!tenantId) {
+      return error(400, "tenantId ausente");
+    }
+
+    const redis  = Redis.fromEnv();
+    const [pwHash, monitor] = await redis.mget(
+      `tenant:${tenantId}:pwHash`,
+      `monitor:${tenantId}`
+    );
+    if (!pwHash && !monitor) {
+      return error(404, "Link inválido");
+    }
+    const prefix = `tenant:${tenantId}:`;
+
+    const [raw, attendedSet] = await Promise.all([
+      redis.lrange(prefix + "log:attended", 0, 49),
+      redis.smembers(prefix + "attendedSet"),
+    ]);
+    const list = raw.map(s => JSON.parse(s)).sort((a, b) => b.ts - a.ts);
+    const nums = attendedSet.map(n => Number(n));
+
+    return json(200, { attended: list, numbers: nums, count: nums.length });
+  } catch (error) {
+    return errorHandler(error);
   }
-
-  const redis  = Redis.fromEnv();
-  const [pwHash, monitor] = await redis.mget(
-    `tenant:${tenantId}:pwHash`,
-    `monitor:${tenantId}`
-  );
-  if (!pwHash && !monitor) {
-    return error(404, "Link inválido");
-  }
-  const prefix = `tenant:${tenantId}:`;
-
-  const [raw, attendedSet] = await Promise.all([
-    redis.lrange(prefix + "log:attended", 0, 49),
-    redis.smembers(prefix + "attendedSet"),
-  ]);
-  const list = raw.map(s => JSON.parse(s)).sort((a, b) => b.ts - a.ts);
-  const nums = attendedSet.map(n => Number(n));
-
-  return json(200, { attended: list, numbers: nums, count: nums.length });
 }

--- a/functions/cancelClone.js
+++ b/functions/cancelClone.js
@@ -1,4 +1,5 @@
 import { Redis } from '@upstash/redis';
+import errorHandler from './utils/errorHandler.js';
 import { error, json } from './utils/response.js';
 
 export async function handler(event) {
@@ -10,8 +11,7 @@ export async function handler(event) {
     const redis = Redis.fromEnv();
     await redis.srem(`tenant:${token}:clones`, cloneId);
     return json(200, { ok: true });
-  } catch (e) {
-    console.error('cancelClone error', e);
-    return error(500, 'Erro no servidor');
+  } catch (error) {
+    return errorHandler(error);
   }
 }

--- a/functions/cancelados.js
+++ b/functions/cancelados.js
@@ -1,47 +1,52 @@
 import { Redis } from "@upstash/redis";
+import errorHandler from "./utils/errorHandler.js";
 import { error, json } from "./utils/response.js";
 
 export async function handler(event) {
-  const url      = new URL(event.rawUrl);
-  const tenantId = url.searchParams.get("t");
-  if (!tenantId) {
-    return error(400, "tenantId ausente");
+  try {
+    const url      = new URL(event.rawUrl);
+    const tenantId = url.searchParams.get("t");
+    if (!tenantId) {
+      return error(400, "tenantId ausente");
+    }
+
+    const redis  = Redis.fromEnv();
+    const [pwHash, monitor] = await redis.mget(
+      `tenant:${tenantId}:pwHash`,
+      `monitor:${tenantId}`
+    );
+    if (!pwHash && !monitor) {
+      return error(404, "Link inválido");
+    }
+    const prefix = `tenant:${tenantId}:`;
+
+    // Últimos 50 cancelamentos e tickets cancelados atualmente
+    const [raw, cancelledArr, missedArr] = await Promise.all([
+      redis.lrange(prefix + "log:cancelled", 0, 49),
+      redis.smembers(prefix + "cancelledSet"),
+      redis.smembers(prefix + "missedSet")
+    ]);
+    const all = raw.map(s => JSON.parse(s));
+    const cancelledSet = new Set(cancelledArr);
+    const missedSet    = new Set(missedArr);
+    const cancelled = all
+      .filter(r => r.reason !== "missed" && cancelledSet.has(String(r.ticket)))
+      .sort((a, b) => b.ts - a.ts);
+    const missed = all
+      .filter(r => r.reason === "missed" && missedSet.has(String(r.ticket)))
+      .sort((a, b) => b.ts - a.ts);
+    const nums = Array.from(cancelledSet).map(n => Number(n));
+    const missedNums = Array.from(missedSet).map(n => Number(n));
+
+    return json(200, {
+      cancelled,
+      numbers: nums,
+      count: nums.length,
+      missed,
+      missedNumbers: missedNums,
+      missedCount: missedNums.length,
+    });
+  } catch (error) {
+    return errorHandler(error);
   }
-
-  const redis  = Redis.fromEnv();
-  const [pwHash, monitor] = await redis.mget(
-    `tenant:${tenantId}:pwHash`,
-    `monitor:${tenantId}`
-  );
-  if (!pwHash && !monitor) {
-    return error(404, "Link inválido");
-  }
-  const prefix = `tenant:${tenantId}:`;
-
-  // Últimos 50 cancelamentos e tickets cancelados atualmente
-  const [raw, cancelledArr, missedArr] = await Promise.all([
-    redis.lrange(prefix + "log:cancelled", 0, 49),
-    redis.smembers(prefix + "cancelledSet"),
-    redis.smembers(prefix + "missedSet")
-  ]);
-  const all = raw.map(s => JSON.parse(s));
-  const cancelledSet = new Set(cancelledArr);
-  const missedSet    = new Set(missedArr);
-  const cancelled = all
-    .filter(r => r.reason !== "missed" && cancelledSet.has(String(r.ticket)))
-    .sort((a, b) => b.ts - a.ts);
-  const missed = all
-    .filter(r => r.reason === "missed" && missedSet.has(String(r.ticket)))
-    .sort((a, b) => b.ts - a.ts);
-  const nums = Array.from(cancelledSet).map(n => Number(n));
-  const missedNums = Array.from(missedSet).map(n => Number(n));
-
-  return json(200, {
-    cancelled,
-    numbers: nums,
-    count: nums.length,
-    missed,
-    missedNumbers: missedNums,
-    missedCount: missedNums.length,
-  });
 }

--- a/functions/cancelar.js
+++ b/functions/cancelar.js
@@ -1,92 +1,97 @@
 import { Redis } from "@upstash/redis";
+import errorHandler from "./utils/errorHandler.js";
 import { error, json } from "./utils/response.js";
 
 const LOG_TTL = 60 * 60 * 24 * 30; // 30 days
 
 export async function handler(event) {
-  const url      = new URL(event.rawUrl);
-  const tenantId = url.searchParams.get("t");
-  if (!tenantId) {
-    return error(400, "tenantId ausente");
-  }
-
-  const redis  = Redis.fromEnv();
-  const [pwHash, monitor] = await redis.mget(
-    `tenant:${tenantId}:pwHash`,
-    `monitor:${tenantId}`
-  );
-  if (!pwHash && !monitor) {
-    return error(404, "Link inválido");
-  }
-  const prefix = `tenant:${tenantId}:`;
-  const { clientId, ticket, reason = "client", duration } = JSON.parse(event.body || "{}");
-
-  // Recupera o número do ticket via clientId ou usa o fornecido diretamente
-  let ticketNum;
-  if (ticket !== undefined && ticket !== null) {
-    ticketNum = String(ticket);
-  } else {
-    ticketNum = await redis.get(prefix + `ticket:${clientId}`);
-    await redis.del(prefix + `ticket:${clientId}`);
-  }
-  if (ticketNum) {
-    await redis.srem(prefix + "offHoursSet", ticketNum);
-    await redis.lrem(prefix + "priorityQueue", 0, ticketNum);
-    await redis.srem(prefix + "prioritySet", ticketNum);
-  }
-
-  let wait = 0;
-  if (ticketNum) {
-    const joinTs = await redis.get(prefix + `ticketTime:${ticketNum}`);
-    if (joinTs) {
-      wait = Date.now() - Number(joinTs);
-      // mantém ticketTime para referência futura
+  try {
+    const url      = new URL(event.rawUrl);
+    const tenantId = url.searchParams.get("t");
+    if (!tenantId) {
+      return error(400, "tenantId ausente");
     }
-  }
 
-  const attended = ticketNum
-    ? await redis.sismember(prefix + "attendedSet", ticketNum)
-    : false;
-
-  // Se havia ticket e não foi atendido, marca cancelamento
-  if (ticketNum && !attended) {
-    if (reason === "missed") {
-      await redis.sadd(prefix + "missedSet", ticketNum);
-    } else {
-      await redis.sadd(prefix + "cancelledSet", ticketNum);
-    }
-    // registro do cancelamento com timestamp
-    const ts = Date.now();
-    const calledTs = Number((await redis.get(prefix + `calledTime:${ticketNum}`)) || 0);
-    const dur = calledTs ? Date.now() - calledTs : duration ? Number(duration) : 0;
-    await redis.set(prefix + `cancelledTime:${ticketNum}`, ts);
-    await redis.lpush(
-      prefix + "log:cancelled",
-      JSON.stringify({ ticket: Number(ticketNum), ts, reason, duration: dur, wait })
+    const redis  = Redis.fromEnv();
+    const [pwHash, monitor] = await redis.mget(
+      `tenant:${tenantId}:pwHash`,
+      `monitor:${tenantId}`
     );
-    await redis.ltrim(prefix + "log:cancelled", 0, 999);
-    await redis.expire(prefix + "log:cancelled", LOG_TTL);
-    await redis.del(prefix + `wait:${ticketNum}`);
+    if (!pwHash && !monitor) {
+      return error(404, "Link inválido");
+    }
+    const prefix = `tenant:${tenantId}:`;
+    const { clientId, ticket, reason = "client", duration } = JSON.parse(event.body || "{}");
 
-    // Se o ticket cancelado era o atual, limpa a chamada
-    const currentCall = Number((await redis.get(prefix + "currentCall")) || 0);
-    if (currentCall === Number(ticketNum)) {
-      await redis.mset({
-        [prefix + "currentCall"]: 0,
-        [prefix + "currentCallTs"]: 0,
-        [prefix + "currentCallPriority"]: 0,
-      });
-      await redis.del(prefix + "currentAttendant");
+    // Recupera o número do ticket via clientId ou usa o fornecido diretamente
+    let ticketNum;
+    if (ticket !== undefined && ticket !== null) {
+      ticketNum = String(ticket);
+    } else {
+      ticketNum = await redis.get(prefix + `ticket:${clientId}`);
+      await redis.del(prefix + `ticket:${clientId}`);
+    }
+    if (ticketNum) {
+      await redis.srem(prefix + "offHoursSet", ticketNum);
+      await redis.lrem(prefix + "priorityQueue", 0, ticketNum);
+      await redis.srem(prefix + "prioritySet", ticketNum);
     }
 
-    return json(200, { cancelled: true, ticket: Number(ticketNum), ts, reason, duration: dur, wait });
-  }
+    let wait = 0;
+    if (ticketNum) {
+      const joinTs = await redis.get(prefix + `ticketTime:${ticketNum}`);
+      if (joinTs) {
+        wait = Date.now() - Number(joinTs);
+        // mantém ticketTime para referência futura
+      }
+    }
 
-  // Se já havia sido atendido, apenas confirme
-  if (ticketNum && attended) {
-    return json(200, { alreadyAttended: true, ticket: Number(ticketNum) });
-  }
+    const attended = ticketNum
+      ? await redis.sismember(prefix + "attendedSet", ticketNum)
+      : false;
 
-  // Nada a cancelar
-  return json(200, { cancelled: false });
+    // Se havia ticket e não foi atendido, marca cancelamento
+    if (ticketNum && !attended) {
+      if (reason === "missed") {
+        await redis.sadd(prefix + "missedSet", ticketNum);
+      } else {
+        await redis.sadd(prefix + "cancelledSet", ticketNum);
+      }
+      // registro do cancelamento com timestamp
+      const ts = Date.now();
+      const calledTs = Number((await redis.get(prefix + `calledTime:${ticketNum}`)) || 0);
+      const dur = calledTs ? Date.now() - calledTs : duration ? Number(duration) : 0;
+      await redis.set(prefix + `cancelledTime:${ticketNum}`, ts);
+      await redis.lpush(
+        prefix + "log:cancelled",
+        JSON.stringify({ ticket: Number(ticketNum), ts, reason, duration: dur, wait })
+      );
+      await redis.ltrim(prefix + "log:cancelled", 0, 999);
+      await redis.expire(prefix + "log:cancelled", LOG_TTL);
+      await redis.del(prefix + `wait:${ticketNum}`);
+
+      // Se o ticket cancelado era o atual, limpa a chamada
+      const currentCall = Number((await redis.get(prefix + "currentCall")) || 0);
+      if (currentCall === Number(ticketNum)) {
+        await redis.mset({
+          [prefix + "currentCall"]: 0,
+          [prefix + "currentCallTs"]: 0,
+          [prefix + "currentCallPriority"]: 0,
+        });
+        await redis.del(prefix + "currentAttendant");
+      }
+
+      return json(200, { cancelled: true, ticket: Number(ticketNum), ts, reason, duration: dur, wait });
+    }
+
+    // Se já havia sido atendido, apenas confirme
+    if (ticketNum && attended) {
+      return json(200, { alreadyAttended: true, ticket: Number(ticketNum) });
+    }
+
+    // Nada a cancelar
+    return json(200, { cancelled: false });
+  } catch (error) {
+    return errorHandler(error);
+  }
 }

--- a/functions/changePassword.js
+++ b/functions/changePassword.js
@@ -1,4 +1,5 @@
 import { Redis } from '@upstash/redis';
+import errorHandler from './utils/errorHandler.js';
 import bcrypt from 'bcryptjs';
 import { error, json } from './utils/response.js';
 
@@ -21,8 +22,7 @@ export async function handler(event) {
     await redis.set(`tenant:${token}:pwHash`, newHash);
     await redis.incr(`tenant:${token}:logoutVersion`);
     return json(200, { ok: true });
-  } catch (e) {
-    console.error('changePassword error', e);
-    return error(500, 'Erro no servidor');
+  } catch (error) {
+    return errorHandler(error);
   }
 }

--- a/functions/debugMonitorData.js
+++ b/functions/debugMonitorData.js
@@ -1,4 +1,5 @@
 import { Redis } from '@upstash/redis';
+import errorHandler from './utils/errorHandler.js';
 import bcrypt from 'bcryptjs';
 import { error, json } from './utils/response.js';
 
@@ -8,56 +9,54 @@ const redisClient = new Redis({
 });
 
 export async function handler(event) {
-  if (event.httpMethod !== 'POST') {
-    return error(405, 'Método não permitido');
-  }
-
-  let body;
   try {
-    body = JSON.parse(event.body);
-  } catch {
-    return error(400, 'JSON inválido');
-  }
+    if (event.httpMethod !== 'POST') {
+      return error(405, 'Método não permitido');
+    }
 
-  const { token, senha } = body;
-  if (!token || !senha) {
-    return error(400, 'Token ou senha ausente');
-  }
+    let body;
+    try {
+      body = JSON.parse(event.body);
+    } catch {
+      return error(400, 'JSON inválido');
+    }
 
-  let data, pwHash;
-  try {
-    [data, pwHash] = await redisClient.mget(
+    const { token, senha } = body;
+    if (!token || !senha) {
+      return error(400, 'Token ou senha ausente');
+    }
+
+    const [data, pwHash] = await redisClient.mget(
       `monitor:${token}`,
       `tenant:${token}:pwHash`
     );
-  } catch (err) {
-    console.error('Redis mget error:', err);
-    return error(500, err.message);
+
+    let stored;
+    try {
+      stored = data ? (typeof data === 'string' ? JSON.parse(data) : data) : null;
+    } catch {
+      return error(500, 'Dados inválidos no Redis');
+    }
+
+    const empresa = stored ? stored.empresa : null;
+    const schedule = stored ? stored.schedule : null;
+    const tokenRedis = stored ? token : null;
+    const tokenMatch = !!stored;
+
+    const valid = pwHash ? await bcrypt.compare(senha, pwHash) : false;
+    const inputHash = pwHash ? bcrypt.hashSync(senha, pwHash) : null;
+
+    return json(200, {
+      empresa,
+      schedule,
+      pwHash: pwHash || null,
+      inputHash,
+      valid,
+      tokenIn: token,
+      tokenRedis,
+      tokenMatch,
+    });
+  } catch (error) {
+    return errorHandler(error);
   }
-
-  let stored;
-  try {
-    stored = data ? (typeof data === 'string' ? JSON.parse(data) : data) : null;
-  } catch {
-    return error(500, 'Dados inválidos no Redis');
-  }
-
-  const empresa = stored ? stored.empresa : null;
-  const schedule = stored ? stored.schedule : null;
-  const tokenRedis = stored ? token : null;
-  const tokenMatch = !!stored;
-
-  const valid = pwHash ? await bcrypt.compare(senha, pwHash) : false;
-  const inputHash = pwHash ? bcrypt.hashSync(senha, pwHash) : null;
-
-  return json(200, {
-    empresa,
-    schedule,
-    pwHash: pwHash || null,
-    inputHash,
-    valid,
-    tokenIn: token,
-    tokenRedis,
-    tokenMatch,
-  });
 }

--- a/functions/getMonitorConfig.js
+++ b/functions/getMonitorConfig.js
@@ -1,4 +1,5 @@
 import { Redis } from '@upstash/redis';
+import errorHandler from './utils/errorHandler.js';
 import bcrypt from 'bcryptjs';
 import { error, json } from './utils/response.js';
 
@@ -8,68 +9,66 @@ const redisClient = new Redis({
 });
 
 export async function handler(event) {
-  if (event.httpMethod !== 'POST') {
-    return error(405, 'Método não permitido');
-  }
-
-  let body;
   try {
-    body = JSON.parse(event.body);
-  } catch {
-    return error(400, 'JSON inválido');
-  }
+    if (event.httpMethod !== 'POST') {
+      return error(405, 'Método não permitido');
+    }
 
-  const { token, senha } = body;
-  if (!token || !senha) {
-    return error(400, 'Token ou senha ausente');
-  }
+    let body;
+    try {
+      body = JSON.parse(event.body);
+    } catch {
+      return error(400, 'JSON inválido');
+    }
 
-  let data, hash;
-  try {
-    [data, hash] = await redisClient.mget(
+    const { token, senha } = body;
+    if (!token || !senha) {
+      return error(400, 'Token ou senha ausente');
+    }
+
+    const [data, hash] = await redisClient.mget(
       `monitor:${token}`,
       `tenant:${token}:pwHash`
     );
-  } catch (err) {
-    console.error('Redis fetch error:', err);
-    return error(500, err.message);
-  }
 
-  if (!data) {
-    return error(404, 'Configuração não encontrada');
-  }
-  if (!hash) {
-    return error(404, 'Senha não configurada');
-  }
-
-  let stored;
-  try {
-    stored = data ? (typeof data === 'string' ? JSON.parse(data) : data) : null;
-  } catch {
-    return error(500, 'Dados inválidos no Redis');
-  }
-
-  if (!stored) {
-    return error(404, 'Configuração não encontrada');
-  }
-
-  const valid = await bcrypt.compare(senha, hash);
-  if (!valid) {
-    return error(403, 'Senha inválida');
-  }
-
-  let schedule = stored.schedule;
-  if (!schedule) {
-    try {
-      const schedRaw = await redisClient.get(`tenant:${token}:schedule`);
-      if (schedRaw) {
-        schedule = typeof schedRaw === 'string' ? JSON.parse(schedRaw) : schedRaw;
-      }
-    } catch (err) {
-      console.error('schedule fetch error:', err);
+    if (!data) {
+      return error(404, 'Configuração não encontrada');
     }
-  }
-  const preferentialDesk = stored.preferentialDesk !== false;
+    if (!hash) {
+      return error(404, 'Senha não configurada');
+    }
 
-  return json(200, { empresa: stored.empresa, schedule, preferentialDesk });
+    let stored;
+    try {
+      stored = data ? (typeof data === 'string' ? JSON.parse(data) : data) : null;
+    } catch {
+      return error(500, 'Dados inválidos no Redis');
+    }
+
+    if (!stored) {
+      return error(404, 'Configuração não encontrada');
+    }
+
+    const valid = await bcrypt.compare(senha, hash);
+    if (!valid) {
+      return error(403, 'Senha inválida');
+    }
+
+    let schedule = stored.schedule;
+    if (!schedule) {
+      try {
+        const schedRaw = await redisClient.get(`tenant:${token}:schedule`);
+        if (schedRaw) {
+          schedule = typeof schedRaw === 'string' ? JSON.parse(schedRaw) : schedRaw;
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+    const preferentialDesk = stored.preferentialDesk !== false;
+
+    return json(200, { empresa: stored.empresa, schedule, preferentialDesk });
+  } catch (error) {
+    return errorHandler(error);
+  }
 }

--- a/functions/getSchedule.js
+++ b/functions/getSchedule.js
@@ -1,4 +1,5 @@
 import { Redis } from '@upstash/redis';
+import errorHandler from './utils/errorHandler.js';
 import { error, json } from './utils/response.js';
 
 const redis = new Redis({
@@ -7,11 +8,11 @@ const redis = new Redis({
 });
 
 export async function handler(event) {
-  const token = event.queryStringParameters && event.queryStringParameters.t;
-  if (!token) {
-    return error(400, 'Token ausente');
-  }
   try {
+    const token = event.queryStringParameters && event.queryStringParameters.t;
+    if (!token) {
+      return error(400, 'Token ausente');
+    }
     const [schedRaw, monitorRaw, pwHash] = await redis.mget(
       `tenant:${token}:schedule`,
       `monitor:${token}`,
@@ -39,8 +40,7 @@ export async function handler(event) {
       return json(200, { schedule: stored.schedule || null });
     }
     return error(404, 'Configuração não encontrada');
-  } catch (err) {
-    console.error('getSchedule error:', err);
-    return error(500, err.message);
+  } catch (error) {
+    return errorHandler(error);
   }
 }

--- a/functions/getTenantConfig.js
+++ b/functions/getTenantConfig.js
@@ -1,4 +1,5 @@
 import faunadb from 'faunadb';
+import errorHandler from './utils/errorHandler.js';
 import { error, json } from './utils/response.js';
 
 const q = faunadb.query;
@@ -20,8 +21,7 @@ export async function handler(event) {
     };
 
     return json(200, config, { 'Content-Type': 'application/json' });
-  } catch (err) {
-    console.error('Erro em getTenantConfig:', err);
-    return error(err.status || 500, err.message);
+  } catch (error) {
+    return errorHandler(error);
   }
 }

--- a/functions/listClones.js
+++ b/functions/listClones.js
@@ -1,4 +1,5 @@
 import { Redis } from '@upstash/redis';
+import errorHandler from './utils/errorHandler.js';
 import { error, json } from './utils/response.js';
 
 export async function handler(event) {
@@ -11,8 +12,7 @@ export async function handler(event) {
     const redis = Redis.fromEnv();
     const clones = await redis.smembers(`tenant:${token}:clones`);
     return json(200, { clones });
-  } catch (e) {
-    console.error('listClones error', e);
-    return error(500, 'Erro no servidor');
+  } catch (error) {
+    return errorHandler(error);
   }
 }

--- a/functions/manualTicket.js
+++ b/functions/manualTicket.js
@@ -1,45 +1,50 @@
 import { Redis } from "@upstash/redis";
+import errorHandler from "./utils/errorHandler.js";
 import { error, json } from "./utils/response.js";
 
 const LOG_TTL = 60 * 60 * 24 * 30; // 30 days
 
 export async function handler(event) {
-  const url = new URL(event.rawUrl);
-  const tenantId = url.searchParams.get("t");
-  if (!tenantId) {
-    return error(400, "tenantId ausente");
+  try {
+    const url = new URL(event.rawUrl);
+    const tenantId = url.searchParams.get("t");
+    if (!tenantId) {
+      return error(400, "tenantId ausente");
+    }
+
+    const redis = Redis.fromEnv();
+    const [pwHash, monitor] = await redis.mget(
+      `tenant:${tenantId}:pwHash`,
+      `monitor:${tenantId}`
+    );
+    if (!pwHash && !monitor) {
+      return error(404, "Link inválido");
+    }
+    const { name = "", priority: bodyPriority } = JSON.parse(event.body || "{}");
+    const priorityParam = bodyPriority ?? url.searchParams.get("priority");
+    const priority = priorityParam === true || priorityParam === "true";
+
+    const prefix = `tenant:${tenantId}:`;
+
+    const ticketNumber = await redis.incr(prefix + "ticketCounter");
+    await redis.set(prefix + `ticketTime:${ticketNumber}`, Date.now());
+    if (name) {
+      await redis.hset(prefix + "ticketNames", { [ticketNumber]: name });
+    }
+
+    if (priority) {
+      await redis.rpush(prefix + "priorityQueue", ticketNumber);
+      await redis.sadd(prefix + "prioritySet", String(ticketNumber));
+      await redis.sadd(prefix + "priorityHistory", String(ticketNumber));
+    }
+
+    const ts = Date.now();
+    await redis.lpush(prefix + "log:entered", JSON.stringify({ ticket: ticketNumber, ts, name }));
+    await redis.ltrim(prefix + "log:entered", 0, 999);
+    await redis.expire(prefix + "log:entered", LOG_TTL);
+
+    return json(200, { ticketNumber, name, ts });
+  } catch (error) {
+    return errorHandler(error);
   }
-
-  const redis = Redis.fromEnv();
-  const [pwHash, monitor] = await redis.mget(
-    `tenant:${tenantId}:pwHash`,
-    `monitor:${tenantId}`
-  );
-  if (!pwHash && !monitor) {
-    return error(404, "Link inválido");
-  }
-  const { name = "", priority: bodyPriority } = JSON.parse(event.body || "{}");
-  const priorityParam = bodyPriority ?? url.searchParams.get("priority");
-  const priority = priorityParam === true || priorityParam === "true";
-
-  const prefix = `tenant:${tenantId}:`;
-
-  const ticketNumber = await redis.incr(prefix + "ticketCounter");
-  await redis.set(prefix + `ticketTime:${ticketNumber}`, Date.now());
-  if (name) {
-    await redis.hset(prefix + "ticketNames", { [ticketNumber]: name });
-  }
-
-  if (priority) {
-    await redis.rpush(prefix + "priorityQueue", ticketNumber);
-    await redis.sadd(prefix + "prioritySet", String(ticketNumber));
-    await redis.sadd(prefix + "priorityHistory", String(ticketNumber));
-  }
-
-  const ts = Date.now();
-  await redis.lpush(prefix + "log:entered", JSON.stringify({ ticket: ticketNumber, ts, name }));
-  await redis.ltrim(prefix + "log:entered", 0, 999);
-  await redis.expire(prefix + "log:entered", LOG_TTL);
-
-  return json(200, { ticketNumber, name, ts });
 }

--- a/functions/registerClone.js
+++ b/functions/registerClone.js
@@ -1,4 +1,5 @@
 import { Redis } from '@upstash/redis';
+import errorHandler from './utils/errorHandler.js';
 import { error, json } from './utils/response.js';
 
 export async function handler(event) {
@@ -10,8 +11,7 @@ export async function handler(event) {
     const redis = Redis.fromEnv();
     await redis.sadd(`tenant:${token}:clones`, cloneId);
     return json(200, { ok: true });
-  } catch (e) {
-    console.error('registerClone error', e);
-    return error(500, 'Erro no servidor');
+  } catch (error) {
+    return errorHandler(error);
   }
 }

--- a/functions/registerMonitor.js
+++ b/functions/registerMonitor.js
@@ -1,5 +1,6 @@
 // functions/registerMonitor.js
 import { Redis } from '@upstash/redis';
+import errorHandler from './utils/errorHandler.js';
 import bcrypt from 'bcryptjs';
 import { error, json } from './utils/response.js';
 
@@ -28,8 +29,7 @@ export async function handler(event) {
     await redis.del(`tenant:${tenantId}:clones`);
 
     return json(200, { success: true, tenantId });
-  } catch (err) {
-    console.error('registerMonitor error', err);
-    return error(500, 'Erro no servidor');
+  } catch (error) {
+    return errorHandler(error);
   }
 }

--- a/functions/status.js
+++ b/functions/status.js
@@ -3,10 +3,12 @@
 import { Redis } from "@upstash/redis";
 import { withinSchedule } from "./utils/schedule.js";
 import { error, json } from "./utils/response.js";
+import errorHandler from "./utils/errorHandler.js";
 
 export async function handler(event) {
-  const url      = new URL(event.rawUrl);
-  const tenantId = url.searchParams.get("t");
+  try {
+    const url      = new URL(event.rawUrl);
+    const tenantId = url.searchParams.get("t");
   if (!tenantId) {
     return error(400, "tenantId ausente");
   }
@@ -143,4 +145,7 @@ export async function handler(event) {
     logoutVersion: Number(logoutVersionRaw || 0),
     preferentialDesk,
   });
+  } catch (error) {
+    return errorHandler(error);
+  }
 }

--- a/functions/validatePassword.js
+++ b/functions/validatePassword.js
@@ -1,5 +1,6 @@
 // functions/validatePassword.js
 import { Redis } from '@upstash/redis';
+import errorHandler from './utils/errorHandler.js';
 import bcrypt from 'bcryptjs';
 import { error, json } from './utils/response.js';
 
@@ -31,8 +32,7 @@ export async function handler(event) {
       : '';
 
     return json(200, { valid, label });
-  } catch (err) {
-    console.error('validatePassword error', err);
-    return error(500, 'Erro no servidor');
+  } catch (error) {
+    return errorHandler(error);
   }
 }


### PR DESCRIPTION
## Summary
- wrap all serverless handlers in try/catch blocks and delegate failures to a shared `errorHandler`
- remove direct `console.error` statements, relying on centralized logging
- document unified JSON error format in the README

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c535bfbec48329b1c4e22fae41699c